### PR TITLE
Use reference instead of pointers to std::array or std::vector in method arguments (issue #1)

### DIFF
--- a/src/tdme/application/Application.cpp
+++ b/src/tdme/application/Application.cpp
@@ -80,7 +80,7 @@ void Application::run(int argc, char** argv, const string& title, ApplicationInp
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA | GLUT_DEPTH | GLUT_3_2_CORE_PROFILE);
 #elif ((defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__)) && !defined(__arm__) && !defined(__aarch64__)) || defined(_WIN32)
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGBA | GLUT_DEPTH);
-	glutInitContextVersion(4,3);
+//	glutInitContextVersion(4,3);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
 	/*
 	glutInitContextVersion(3, 1);

--- a/src/tdme/engine/fileio/models/DAEReader.cpp
+++ b/src/tdme/engine/fileio/models/DAEReader.cpp
@@ -1,7 +1,6 @@
 #include <tdme/engine/fileio/models/DAEReader.h>
 
 #include <map>
-#include <map>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -572,7 +571,7 @@ Group* DAEReader::readVisualSceneInstanceController(const string& pathName, Mode
 			}
 		}
 	}
-	skinning->setJoints(&joints);
+	skinning->setJoints(joints);
 
 	// check for inverse bind matrices source
 	if (xmlJointsInverseBindMatricesSource.length() == 0) {
@@ -684,7 +683,7 @@ Group* DAEReader::readVisualSceneInstanceController(const string& pathName, Mode
 		}
 		verticesJointsWeights.push_back(vertexJointsWeights);
 	}
-	skinning->setVerticesJointsWeights(&verticesJointsWeights);
+	skinning->setVerticesJointsWeights(verticesJointsWeights);
 
 	return group;
 }
@@ -944,11 +943,11 @@ void DAEReader::readGeometry(const string& pathName, Model* model, Group* group,
 	}
 
 	// set up group
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
+	group->setVertices(vertices);
+	group->setNormals(normals);
 	if (textureCoordinates.size() > 0)
-		group->setTextureCoordinates(&textureCoordinates);
-	group->setFacesEntities(&facesEntities);
+		group->setTextureCoordinates(textureCoordinates);
+	group->setFacesEntities(facesEntities);
 	// create normal tangents and bitangents
 	ModelHelper::createNormalTangentsAndBitangents(group);
 	// determine features
@@ -1261,7 +1260,7 @@ const string DAEReader::determineDisplacementFilename(const string& path, const 
 	// try to find file in path file listing
 	try {
 		vector<string> fileNameCandidates;
-		FileSystem::getInstance()->list(path, &fileNameCandidates, new DAEReader_determineDisplacementFilename_1(tmpFileNameCandidate));
+		FileSystem::getInstance()->list(path, fileNameCandidates, new DAEReader_determineDisplacementFilename_1(tmpFileNameCandidate));
 		if (fileNameCandidates.size() > 0) {
 			return fileNameCandidates[0];
 		}

--- a/src/tdme/engine/fileio/models/DAEReader.h
+++ b/src/tdme/engine/fileio/models/DAEReader.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <map>
@@ -138,7 +137,7 @@ private:
 	 * @param materialSymbols material symbols
 	 * @throws model file IO exception
 	 */
-	static void readGeometry(const string& pathName, Model* model, Group* group, TiXmlElement* xmlRoot, const string& xmlNodeId, const map<string, string>* materialSymbols) throw (ModelFileIOException);
+	static void readGeometry(const string& pathName, Model* model, Group* group, TiXmlElement* xmlRoot, const string& xmlNodeId, const map<string, string>* materialSymbols) throw (ModelFileIOException); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Reads a material

--- a/src/tdme/engine/fileio/models/ModelReader.h
+++ b/src/tdme/engine/fileio/models/ModelReader.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <string>

--- a/src/tdme/engine/fileio/models/TMReader.cpp
+++ b/src/tdme/engine/fileio/models/TMReader.cpp
@@ -101,7 +101,7 @@ Model* TMReader::read(const string& pathName, const string& fileName) throw (Fil
 	);
 	model->setFPS(is.readFloat());
 	array<float, 16> importTransformationsMatrixArray;
-	is.readFloatArray(&importTransformationsMatrixArray);
+	is.readFloatArray(importTransformationsMatrixArray);
 	model->getImportTransformationsMatrix().set(importTransformationsMatrixArray);
 	auto materialCount = is.readInt();
 	for (auto i = 0; i < materialCount; i++) {
@@ -138,13 +138,13 @@ Material* TMReader::readMaterial(const string& pathName, TMReaderInputStream* is
 	auto id = is->readString();
 	auto m = new Material(id);
 	array<float, 4> colorRGBAArray;
-	is->readFloatArray(&colorRGBAArray);
+	is->readFloatArray(colorRGBAArray);
 	m->setAmbientColor(Color4(colorRGBAArray));
-	is->readFloatArray(&colorRGBAArray);
+	is->readFloatArray(colorRGBAArray);
 	m->setDiffuseColor(Color4(colorRGBAArray));
-	is->readFloatArray(&colorRGBAArray);
+	is->readFloatArray(colorRGBAArray);
 	m->setSpecularColor(Color4(colorRGBAArray));
-	is->readFloatArray(&colorRGBAArray);
+	is->readFloatArray(colorRGBAArray);
 	m->setEmissionColor(Color4(colorRGBAArray));
 	m->setShininess(is->readFloat());
 	auto diffuseTexturePathName = is->readString();
@@ -255,7 +255,7 @@ Animation* TMReader::readAnimation(TMReaderInputStream* is, Group* g) throw (Mod
 		array<float, 16> matrixArray;
 		g->createAnimation(is->readInt());
 		for (auto i = 0; i < g->getAnimation()->getTransformationsMatrices()->size(); i++) {
-			is->readFloatArray(&matrixArray);
+			is->readFloatArray(matrixArray);
 			(*g->getAnimation()->getTransformationsMatrices())[i].set(matrixArray);
 		}
 		return g->getAnimation();
@@ -315,7 +315,7 @@ Joint TMReader::readSkinningJoint(TMReaderInputStream* is) throw (ModelFileIOExc
 {
 	array<float, 16> matrixArray;
 	Joint joint(is->readString());
-	is->readFloatArray(&matrixArray);
+	is->readFloatArray(matrixArray);
 	joint.getBindMatrix().set(matrixArray);
 	return joint;
 }
@@ -369,7 +369,7 @@ Group* TMReader::readGroup(TMReaderInputStream* is, Model* model, Group* parentG
 	auto group = new Group(model, parentGroup, groupId, groupName);
 	group->setJoint(is->readBoolean());
 	array<float, 16> matrixArray;
-	is->readFloatArray(&matrixArray);
+	is->readFloatArray(matrixArray);
 	group->getTransformationsMatrix().set(matrixArray);
 	vector<Vector3> vertices = readVertices(is);
 	group->setVertices(&vertices);

--- a/src/tdme/engine/fileio/models/TMReader.cpp
+++ b/src/tdme/engine/fileio/models/TMReader.cpp
@@ -59,7 +59,7 @@ using tdme::os::filesystem::FileSystemInterface;
 Model* TMReader::read(const string& pathName, const string& fileName) throw (FileSystemException, ModelFileIOException)
 {
 	vector<uint8_t> content;
-	FileSystem::getInstance()->getContent(pathName, fileName, &content);
+	FileSystem::getInstance()->getContent(pathName, fileName, content);
 	TMReaderInputStream is(&content);
 	auto fileId = is.readString();
 	if (fileId.length() == 0 || fileId != "TDME Model") {
@@ -308,7 +308,7 @@ void TMReader::readFacesEntities(TMReaderInputStream* is, Group* g) throw (Model
 		}
 		facesEntities[i].setFaces(&faces);
 	}
-	g->setFacesEntities(&facesEntities);
+	g->setFacesEntities(facesEntities);
 }
 
 Joint TMReader::readSkinningJoint(TMReaderInputStream* is) throw (ModelFileIOException)
@@ -338,7 +338,7 @@ void TMReader::readSkinning(TMReaderInputStream* is, Group* g) throw (ModelFileI
 		for (auto i = 0; i < joints.size(); i++) {
 			joints[i] = readSkinningJoint(is);
 		}
-		skinning->setJoints(&joints);
+		skinning->setJoints(joints);
 		vector<vector<JointWeight>> verticesJointsWeight;
 		verticesJointsWeight.resize(is->readInt());
 		for (auto i = 0; i < verticesJointsWeight.size(); i++) {
@@ -347,7 +347,7 @@ void TMReader::readSkinning(TMReaderInputStream* is, Group* g) throw (ModelFileI
 				verticesJointsWeight[i][j] = readSkinningJointWeight(is);
 			}
 		}
-		skinning->setVerticesJointsWeights(&verticesJointsWeight);
+		skinning->setVerticesJointsWeights(verticesJointsWeight);
 	}
 }
 
@@ -372,15 +372,15 @@ Group* TMReader::readGroup(TMReaderInputStream* is, Model* model, Group* parentG
 	is->readFloatArray(matrixArray);
 	group->getTransformationsMatrix().set(matrixArray);
 	vector<Vector3> vertices = readVertices(is);
-	group->setVertices(&vertices);
+	group->setVertices(vertices);
 	vector<Vector3> normals = readVertices(is);
-	group->setNormals(&normals);
+	group->setNormals(normals);
 	vector<TextureCoordinate> textureCoordinates = readTextureCoordinates(is);
-	group->setTextureCoordinates(&textureCoordinates);
+	group->setTextureCoordinates(textureCoordinates);
 	vector<Vector3> tangents = readVertices(is);
-	group->setTangents(&tangents);
+	group->setTangents(tangents);
 	vector<Vector3> bitangents = readVertices(is);
-	group->setBitangents(&bitangents);
+	group->setBitangents(bitangents);
 	readAnimation(is, group);
 	readSkinning(is, group);
 	readFacesEntities(is, group);

--- a/src/tdme/engine/fileio/models/TMReader.h
+++ b/src/tdme/engine/fileio/models/TMReader.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <array>

--- a/src/tdme/engine/fileio/models/TMReader.h
+++ b/src/tdme/engine/fileio/models/TMReader.h
@@ -129,13 +129,13 @@ public:
 	 * @throws model file IO exception
 	 * @return float array
 	 */
-	inline void readFloatArray(array<float, 16>* data) throw (ModelFileIOException) {
+	inline void readFloatArray(array<float, 16>& data) throw (ModelFileIOException) {
 		auto length = readInt();
-		if (length != data->size()) {
+		if (length != data.size()) {
 			throw ModelFileIOException("Wrong float array size");
 		}
-		for (auto i = 0; i < data->size(); i++) {
-			(*data)[i] = readFloat();
+		for (auto i = 0; i < data.size(); i++) {
+			(data)[i] = readFloat();
 		}
 	}
 
@@ -144,13 +144,13 @@ public:
 	 * @throws model file IO exception
 	 * @return float array
 	 */
-	inline void readFloatArray(array<float, 4>* data) throw (ModelFileIOException) {
+	inline void readFloatArray(array<float, 4>& data) throw (ModelFileIOException) {
 		auto length = readInt();
-		if (length != data->size()) {
+		if (length != data.size()) {
 			throw ModelFileIOException("Wrong float array size");
 		}
-		for (auto i = 0; i < data->size(); i++) {
-			(*data)[i] = readFloat();
+		for (auto i = 0; i < data.size(); i++) {
+			(data)[i] = readFloat();
 		}
 	}
 
@@ -333,7 +333,7 @@ private:
 	 * @throws model file IO exception
 	 * @return group
 	 */
-	static void readSubGroups(TMReaderInputStream* is, Model* model, Group* parentGroup, map<string, Group*>* subGroups) throw (ModelFileIOException);
+	static void readSubGroups(TMReaderInputStream* is, Model* model, Group* parentGroup, map<string, Group*>* subGroups) throw (ModelFileIOException); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Write group to output stream

--- a/src/tdme/engine/fileio/models/TMWriter.cpp
+++ b/src/tdme/engine/fileio/models/TMWriter.cpp
@@ -138,7 +138,7 @@ void TMWriter::writeTextureCoordinates(TMWriterOutputStream* os, vector<TextureC
 	}
 }
 
-void TMWriter::writeIndices(TMWriterOutputStream* os, array<int32_t, 3>* indices) throw (ModelFileIOException)
+void TMWriter::writeIndices(TMWriterOutputStream* os, const array<int32_t, 3>* indices) throw (ModelFileIOException)
 {
 	if (indices == nullptr) {
 		os->writeBoolean(false);

--- a/src/tdme/engine/fileio/models/TMWriter.cpp
+++ b/src/tdme/engine/fileio/models/TMWriter.cpp
@@ -79,7 +79,7 @@ void TMWriter::write(Model* model, const string& pathName, const string& fileNam
 		AnimationSetup* animationSetup = it.second;
 		writeAnimationSetup(&os, animationSetup);
 	}
-	FileSystem::getInstance()->setContent(pathName, fileName, os.getData());
+	FileSystem::getInstance()->setContent(pathName, fileName, *os.getData());
 }
 
 void TMWriter::writeMaterial(TMWriterOutputStream* os, Material* m) throw (ModelFileIOException)
@@ -112,20 +112,20 @@ void TMWriter::writeAnimationSetup(TMWriterOutputStream* os, AnimationSetup* ani
 	os->writeBoolean(animationSetup->isLoop());
 }
 
-void TMWriter::writeVertices(TMWriterOutputStream* os, vector<Vector3>* v) throw (ModelFileIOException)
+void TMWriter::writeVertices(TMWriterOutputStream* os, const vector<Vector3>& v) throw (ModelFileIOException)
 {
-	if (v->size() == 0) {
+	if (v.size() == 0) {
 		os->writeBoolean(false);
 	} else {
 		os->writeBoolean(true);
-		os->writeInt(v->size());
-		for (auto i = 0; i < v->size(); i++) {
-			os->writeFloatArray((*v)[i].getArray());
+		os->writeInt(v.size());
+		for (auto i = 0; i < v.size(); i++) {
+			os->writeFloatArray(v[i].getArray());
 		}
 	}
 }
 
-void TMWriter::writeTextureCoordinates(TMWriterOutputStream* os, vector<TextureCoordinate>* tc) throw (ModelFileIOException)
+void TMWriter::writeTextureCoordinates(TMWriterOutputStream* os, vector<TextureCoordinate>* tc) throw (ModelFileIOException) // TODO: change std::vector* argument to std::vector& ?
 {
 	if (tc == nullptr) {
 		os->writeBoolean(false);
@@ -138,7 +138,7 @@ void TMWriter::writeTextureCoordinates(TMWriterOutputStream* os, vector<TextureC
 	}
 }
 
-void TMWriter::writeIndices(TMWriterOutputStream* os, const array<int32_t, 3>* indices) throw (ModelFileIOException)
+void TMWriter::writeIndices(TMWriterOutputStream* os, const array<int32_t, 3>* indices) throw (ModelFileIOException) // TODO: change std::array* argument to std::array& ?
 {
 	if (indices == nullptr) {
 		os->writeBoolean(false);
@@ -164,11 +164,11 @@ void TMWriter::writeAnimation(TMWriterOutputStream* os, Animation* a) throw (Mod
 	}
 }
 
-void TMWriter::writeFacesEntities(TMWriterOutputStream* os, vector<FacesEntity>* facesEntities) throw (ModelFileIOException)
+void TMWriter::writeFacesEntities(TMWriterOutputStream* os, vector<FacesEntity>& facesEntities) throw (ModelFileIOException)
 {
-	os->writeInt(facesEntities->size());
-	for (auto i = 0; i < facesEntities->size(); i++) {
-		auto& fe = (*facesEntities)[i];
+	os->writeInt(facesEntities.size());
+	for (auto i = 0; i < facesEntities.size(); i++) {
+		auto& fe = facesEntities[i];
 		os->writeString(fe.getId());
 		if (fe.getMaterial() == nullptr) {
 			os->writeBoolean(false);
@@ -206,7 +206,7 @@ void TMWriter::writeSkinning(TMWriterOutputStream* os, Skinning* skinning) throw
 		os->writeBoolean(false);
 	} else {
 		os->writeBoolean(true);
-		os->writeFloatArray(skinning->getWeights());
+		os->writeFloatArray(*skinning->getWeights());
 		os->writeInt(skinning->getJoints()->size());
 		for (auto i = 0; i < skinning->getJoints()->size(); i++) {
 			writeSkinningJoint(os, &(*skinning->getJoints())[i]);
@@ -236,13 +236,13 @@ void TMWriter::writeGroup(TMWriterOutputStream* os, Group* g) throw (ModelFileIO
 	os->writeString(g->getName());
 	os->writeBoolean(g->isJoint());
 	os->writeFloatArray(g->getTransformationsMatrix().getArray());
-	writeVertices(os, g->getVertices());
-	writeVertices(os, g->getNormals());
+	writeVertices(os, *g->getVertices());
+	writeVertices(os, *g->getNormals());
 	writeTextureCoordinates(os, g->getTextureCoordinates());
-	writeVertices(os, g->getTangents());
-	writeVertices(os, g->getBitangents());
+	writeVertices(os, *g->getTangents());
+	writeVertices(os, *g->getBitangents());
 	writeAnimation(os, g->getAnimation());
 	writeSkinning(os, g->getSkinning());
-	writeFacesEntities(os, g->getFacesEntities());
+	writeFacesEntities(os, *g->getFacesEntities());
 	writeSubGroups(os, g->getSubGroups());
 }

--- a/src/tdme/engine/fileio/models/TMWriter.h
+++ b/src/tdme/engine/fileio/models/TMWriter.h
@@ -185,10 +185,10 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(const vector<float>* f) throw (ModelFileIOException) {
-		writeInt(f->size());
-		for (auto i = 0; i < f->size(); i++) {
-			writeFloat((*f)[i]);
+	inline void writeFloatArray(const vector<float>& f) throw (ModelFileIOException) {
+		writeInt(f.size());
+		for (auto i = 0; i < f.size(); i++) {
+			writeFloat(f[i]);
 		}
 	}
 
@@ -240,7 +240,7 @@ private:
 	 * @param v vertices
 	 * @throws model file IO exception
 	 */
-	static void writeVertices(TMWriterOutputStream* os, vector<Vector3>* v) throw (ModelFileIOException);
+	static void writeVertices(TMWriterOutputStream* os, const vector<Vector3>& v) throw (ModelFileIOException);
 
 	/** 
 	 * Write texture coordinates to output stream
@@ -272,7 +272,7 @@ private:
 	 * @param facesEntities faces entities
 	 * @throws model file IO exception
 	 */
-	static void writeFacesEntities(TMWriterOutputStream* os, vector<FacesEntity>* facesEntities) throw (ModelFileIOException);
+	static void writeFacesEntities(TMWriterOutputStream* os, vector<FacesEntity>& facesEntities) throw (ModelFileIOException);
 
 	/** 
 	 * Write skinning joint

--- a/src/tdme/engine/fileio/models/TMWriter.h
+++ b/src/tdme/engine/fileio/models/TMWriter.h
@@ -125,7 +125,7 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(array<float,2>& f) throw (ModelFileIOException) {
+	inline void writeFloatArray(const array<float,2>& f) throw (ModelFileIOException) {
 		writeInt(f.size());
 		for (auto i = 0; i < f.size(); i++) {
 			writeFloat(f[i]);
@@ -137,7 +137,7 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(array<float,3>& f) throw (ModelFileIOException) {
+	inline void writeFloatArray(const array<float,3>& f) throw (ModelFileIOException) {
 		writeInt(f.size());
 		for (auto i = 0; i < f.size(); i++) {
 			writeFloat(f[i]);
@@ -149,7 +149,7 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(array<float,4>& f) throw (ModelFileIOException) {
+	inline void writeFloatArray(const array<float,4>& f) throw (ModelFileIOException) {
 		writeInt(f.size());
 		for (auto i = 0; i < f.size(); i++) {
 			writeFloat(f[i]);
@@ -161,7 +161,7 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(array<float,4>* f) throw (ModelFileIOException) {
+	inline void writeFloatArray(const array<float,4>* f) throw (ModelFileIOException) {
 		writeInt(f->size());
 		for (auto i = 0; i < f->size(); i++) {
 			writeFloat((*f)[i]);
@@ -173,7 +173,7 @@ public:
 	 * @param f float array
 	 * @throws model file IO exception
 	 */
-	inline void writeFloatArray(array<float,16>& f) throw (ModelFileIOException) {
+	inline void writeFloatArray(const array<float,16>& f) throw (ModelFileIOException) {
 		writeInt(f.size());
 		for (auto i = 0; i < f.size(); i++) {
 			writeFloat(f[i]);
@@ -256,7 +256,7 @@ private:
 	 * @param indices indices
 	 * @throws model file IO exception
 	 */
-	static void writeIndices(TMWriterOutputStream* os, array<int32_t, 3>* indices) throw (ModelFileIOException);
+	static void writeIndices(TMWriterOutputStream* os, const array<int32_t, 3>* indices) throw (ModelFileIOException);
 
 	/** 
 	 * Write animation to output stream
@@ -304,7 +304,7 @@ private:
 	 * @param subGroups sub groups
 	 * @throws model file IO exception
 	 */
-	static void writeSubGroups(TMWriterOutputStream* os, map<string, Group*>* subGroups) throw (ModelFileIOException);
+	static void writeSubGroups(TMWriterOutputStream* os, map<string, Group*>* subGroups) throw (ModelFileIOException); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Write group to output stream

--- a/src/tdme/engine/fileio/models/WFObjReader.cpp
+++ b/src/tdme/engine/fileio/models/WFObjReader.cpp
@@ -107,7 +107,7 @@ Model* WFObjReader::read(const string& pathName, const string& fileName) throw (
 			StringTokenizer t;
 			StringTokenizer t2;
 			vector<string> lines;
-			FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, &lines);
+			FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, lines);
 			string line;
 			for (int lineIdx = 0; lineIdx < lines.size(); lineIdx++) {
 				line = StringUtils::trim(lines[lineIdx]);
@@ -266,10 +266,10 @@ Model* WFObjReader::read(const string& pathName, const string& fileName) throw (
 							groupFacesEntities.push_back(*groupFacesEntity);
 						}
 						// group
-						group->setVertices(&groupVertices);
-						group->setNormals(&groupNormals);
-						group->setTextureCoordinates(&groupTextureCoordinates);
-						group->setFacesEntities(&groupFacesEntities);
+						group->setVertices(groupVertices);
+						group->setNormals(groupNormals);
+						group->setTextureCoordinates(groupTextureCoordinates);
+						group->setFacesEntities(groupFacesEntities);
 						group->determineFeatures();
 					}
 					t.tokenize(arguments, " ");
@@ -318,12 +318,12 @@ Model* WFObjReader::read(const string& pathName, const string& fileName) throw (
 					groupFacesEntities.push_back(*groupFacesEntity);
 				}
 				// group
-				group->setVertices(&groupVertices);
-				group->setNormals(&groupNormals);
+				group->setVertices(groupVertices);
+				group->setNormals(groupNormals);
 				if (groupTextureCoordinates.size() > 0) {
-					group->setTextureCoordinates(&groupTextureCoordinates);
+					group->setTextureCoordinates(groupTextureCoordinates);
 				}
-				group->setFacesEntities(&groupFacesEntities);
+				group->setFacesEntities(groupFacesEntities);
 				group->determineFeatures();
 			}
 		}
@@ -346,7 +346,7 @@ void WFObjReader::readMaterials(const string& pathName, const string& fileName, 
 		});
 		StringTokenizer t;
 		vector<string> lines;
-		FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, &lines);
+		FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, lines);
 		for (int lineIdx = 0; lineIdx < lines.size(); lineIdx++) {
 			auto line = StringUtils::trim(lines[lineIdx]);
 			// skip on comments

--- a/src/tdme/engine/fileio/models/WFObjReader.cpp
+++ b/src/tdme/engine/fileio/models/WFObjReader.cpp
@@ -239,8 +239,8 @@ Model* WFObjReader::read(const string& pathName, const string& fileName) throw (
 					// compute vertex normal
 					array<Vector3, 3> faceVertexNormals;
 					ModelHelper::computeNormals(
-						&faceVertices,
-						&faceVertexNormals
+						faceVertices,
+						faceVertexNormals
 					);
 					// store group normals
 					auto n0 = groupNormals.size();

--- a/src/tdme/engine/fileio/models/WFObjReader.h
+++ b/src/tdme/engine/fileio/models/WFObjReader.h
@@ -49,5 +49,5 @@ private:
 	 * @throws FileSystemException
 	 * @throws ModelIOException
 	 */
-	static void readMaterials(const string& pathName, const string& fileName, map<string, Material*>* materials) throw (FileSystemException, ModelFileIOException);
+	static void readMaterials(const string& pathName, const string& fileName, map<string, Material*>* materials) throw (FileSystemException, ModelFileIOException); // TODO: std container: maybe use call by reference
 };

--- a/src/tdme/engine/fileio/textures/TextureLoader.cpp
+++ b/src/tdme/engine/fileio/textures/TextureLoader.cpp
@@ -64,7 +64,7 @@ Texture* TextureLoader::loadPNG(const string& pathName, const string& fileName) 
 
 	// create PNG input stream
 	vector<uint8_t> content;
-	FileSystem::getInstance()->getContent(pathName, fileName, &content);
+	FileSystem::getInstance()->getContent(pathName, fileName, content);
 	PNGInputStream* pngInputStream = new PNGInputStream(&content);
 
 	// check that the PNG signature is in the file header

--- a/src/tdme/engine/model/Face.cpp
+++ b/src/tdme/engine/model/Face.cpp
@@ -92,12 +92,12 @@ array<int32_t, 3>* Face::getBitangentIndices()
 	return &bitangentIndices;
 }
 
-void Face::setIndexedRenderingIndices(array<int32_t, 3>* indices)
+void Face::setIndexedRenderingIndices(const array<int32_t, 3>& indices)
 {
-	vertexIndices = *indices;
-	normalIndices = *indices;
-	textureCoordinateIndices = *indices;
-	tangentIndices = *indices;
-	bitangentIndices = *indices;
+	vertexIndices = indices;
+	normalIndices = indices;
+	textureCoordinateIndices = indices;
+	tangentIndices = indices;
+	bitangentIndices = indices;
 }
 

--- a/src/tdme/engine/model/Face.h
+++ b/src/tdme/engine/model/Face.h
@@ -30,7 +30,7 @@ private:
 	 * Prepared this face for indexed rendering
 	 * @param indices indices
 	 */
-	void setIndexedRenderingIndices(array<int32_t, 3>* indices);
+	void setIndexedRenderingIndices(const array<int32_t, 3>& indices);
 
 public:
 	/**

--- a/src/tdme/engine/model/Group.cpp
+++ b/src/tdme/engine/model/Group.cpp
@@ -84,11 +84,11 @@ vector<Vector3>* Group::getVertices()
 	return &vertices;
 }
 
-void Group::setVertices(const vector<Vector3>* vertices)
+void Group::setVertices(const vector<Vector3>& vertices)
 {
-	this->vertices.resize(vertices->size());
+	this->vertices.resize(vertices.size());
 	int i = 0;
-	for (auto& vertex: *vertices) {
+	for (auto& vertex: vertices) {
 		this->vertices[i++] = vertex;
 	}
 }
@@ -98,11 +98,11 @@ vector<Vector3>* Group::getNormals()
 	return &normals;
 }
 
-void Group::setNormals(const vector<Vector3>* normals)
+void Group::setNormals(const vector<Vector3>& normals)
 {
-	this->normals.resize(normals->size());
+	this->normals.resize(normals.size());
 	int i = 0;
-	for (auto& normal: *normals) {
+	for (auto& normal: normals) {
 		this->normals[i++] = normal;
 	}
 }
@@ -112,11 +112,11 @@ vector<TextureCoordinate>* Group::getTextureCoordinates()
 	return &textureCoordinates;
 }
 
-void Group::setTextureCoordinates(const vector<TextureCoordinate>* textureCoordinates)
+void Group::setTextureCoordinates(const vector<TextureCoordinate>& textureCoordinates)
 {
-	this->textureCoordinates.resize(textureCoordinates->size());
+	this->textureCoordinates.resize(textureCoordinates.size());
 	int i = 0;
-	for (auto& textureCoordinate: *textureCoordinates) {
+	for (auto& textureCoordinate: textureCoordinates) {
 		this->textureCoordinates[i++] = textureCoordinate;
 	}
 }
@@ -126,11 +126,11 @@ vector<Vector3>* Group::getTangents()
 	return &tangents;
 }
 
-void Group::setTangents(const vector<Vector3>* tangents)
+void Group::setTangents(const vector<Vector3>& tangents)
 {
-	this->tangents.resize(tangents->size());
+	this->tangents.resize(tangents.size());
 	int i = 0;
-	for (auto& tangent: *tangents) {
+	for (auto& tangent: tangents) {
 		this->tangents[i++] = tangent;
 	}
 }
@@ -140,11 +140,11 @@ vector<Vector3>* Group::getBitangents()
 	return &bitangents;
 }
 
-void Group::setBitangents(const vector<Vector3>* bitangents)
+void Group::setBitangents(const vector<Vector3>& bitangents)
 {
-	this->bitangents.resize(bitangents->size());
+	this->bitangents.resize(bitangents.size());
 	int i = 0;
-	for (auto& bitangent: *bitangents) {
+	for (auto& bitangent: bitangents) {
 		this->bitangents[i++] = bitangent;
 	}
 }
@@ -186,11 +186,11 @@ vector<FacesEntity>* Group::getFacesEntities()
 	return &facesEntities;
 }
 
-void Group::setFacesEntities(const vector<FacesEntity>* facesEntities)
+void Group::setFacesEntities(const vector<FacesEntity>& facesEntities)
 {
-	this->facesEntities.resize(facesEntities->size());
+	this->facesEntities.resize(facesEntities.size());
 	int i = 0;
-	for (auto& facesEntity: *facesEntities) {
+	for (auto& facesEntity: facesEntities) {
 		this->facesEntities[i++] = facesEntity;
 	}
 }

--- a/src/tdme/engine/model/Group.h
+++ b/src/tdme/engine/model/Group.h
@@ -92,7 +92,7 @@ public:
 	 * Set vertices
 	 * @param vertices vertices
 	 */
-	void setVertices(const vector<Vector3>* vertices);
+	void setVertices(const vector<Vector3>& vertices);
 
 	/** 
 	 * @return normals
@@ -103,7 +103,7 @@ public:
 	 * Set normals
 	 * @param normals normals
 	 */
-	void setNormals(const vector<Vector3>* normals);
+	void setNormals(const vector<Vector3>& normals);
 
 	/** 
 	 * @return texture coordinates or null (optional)
@@ -114,7 +114,7 @@ public:
 	 * Set texture coordinates
 	 * @param textureCoordinates texture coordinates
 	 */
-	void setTextureCoordinates(const vector<TextureCoordinate>* textureCoordinates);
+	void setTextureCoordinates(const vector<TextureCoordinate>& textureCoordinates);
 
 	/** 
 	 * @return tangents
@@ -125,7 +125,7 @@ public:
 	 * Set tangents
 	 * @param tangents tangents
 	 */
-	void setTangents(const vector<Vector3>* tangents);
+	void setTangents(const vector<Vector3>& tangents);
 
 	/** 
 	 * @return bitangents
@@ -136,7 +136,7 @@ public:
 	 * Set bitangents
 	 * @param bitangents bitangents
 	 */
-	void setBitangents(const vector<Vector3>* bitangents);
+	void setBitangents(const vector<Vector3>& bitangents);
 
 	/** 
 	 * @return animation
@@ -175,7 +175,7 @@ public:
 	 * Set up faces entities
 	 * @param facesEntities faces entity
 	 */
-	void setFacesEntities(const vector<FacesEntity>* facesEntities);
+	void setFacesEntities(const vector<FacesEntity>& facesEntities);
 
 	/** 
 	 * @return sub sub groups of this group

--- a/src/tdme/engine/model/Model.h
+++ b/src/tdme/engine/model/Model.h
@@ -55,7 +55,7 @@ private:
 	 * Delete sub groups
 	 * @param subGroups sub groups
 	 */
-	void deleteSubGroups(map<string, Group*>* subGroups);
+	void deleteSubGroups(map<string, Group*>* subGroups); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Set up if model has skinning
@@ -72,7 +72,7 @@ private:
 	 * @param transformationsMatrix transformations matrix
 	 * @return target group transformations
 	 */
-	bool computeTransformationsMatrix(map<string, Group*>* groups, const Matrix4x4& parentTransformationsMatrix, int32_t frame, const string& groupId, Matrix4x4& transformationsMatrix);
+	bool computeTransformationsMatrix(map<string, Group*>* groups, const Matrix4x4& parentTransformationsMatrix, int32_t frame, const string& groupId, Matrix4x4& transformationsMatrix); // TODO: std container: maybe use call by reference
 
 public:
 

--- a/src/tdme/engine/model/ModelHelper.cpp
+++ b/src/tdme/engine/model/ModelHelper.cpp
@@ -68,25 +68,25 @@ ModelHelper_VertexOrder* ModelHelper::determineVertexOrder(const vector<Vector3>
 	}
 }
 
-void ModelHelper::computeNormal(array<Vector3,3>* vertices, Vector3& normal)
+void ModelHelper::computeNormal(const array<Vector3,3>& vertices, Vector3& normal)
 {
 	// face normal
 	Vector3::computeCrossProduct(
-		(*vertices)[1].clone().sub((*vertices)[0]),
-		(*vertices)[2].clone().sub((*vertices)[0]),
+		(vertices)[1].clone().sub((vertices)[0]),
+		(vertices)[2].clone().sub((vertices)[0]),
 		normal
 	).normalize();
 }
 
-void ModelHelper::computeNormals(array<Vector3,3> *vertices, array<Vector3,3>* normals)
+void ModelHelper::computeNormals(const array<Vector3,3>& vertices, array<Vector3,3>& normals)
 {
 	// face normal
 	Vector3 normal;
 	computeNormal(vertices, normal);
 
 	// compute vertex normal
-	for (auto i = 0; i < vertices->size(); i++) {
-		(*normals)[i].set(normal);
+	for (auto i = 0; i < vertices.size(); i++) {
+		(normals)[i].set(normal);
 	}
 }
 
@@ -236,7 +236,7 @@ void ModelHelper::prepareForIndexedRendering(map<string, Group*>* groups)
 					}
 					indexedFaceVertexIndices[idx] = newIndex;
 				}
-				face.setIndexedRenderingIndices(&indexedFaceVertexIndices);
+				face.setIndexedRenderingIndices(indexedFaceVertexIndices);
 			}
 		}
 		// remap skinning

--- a/src/tdme/engine/model/ModelHelper.cpp
+++ b/src/tdme/engine/model/ModelHelper.cpp
@@ -150,8 +150,8 @@ void ModelHelper::createNormalTangentsAndBitangents(Group* group)
 
 	// set up tangents and bitangents if we have any
 	if (tangentsArrayList.size() > 0 && bitangentsArrayList.size() > 0) {
-		group->setTangents(&tangentsArrayList);
-		group->setBitangents(&bitangentsArrayList);
+		group->setTangents(tangentsArrayList);
+		group->setBitangents(bitangentsArrayList);
 		// going further
 		auto tangents = group->getTangents();
 		auto bitangents = group->getBitangents();
@@ -242,35 +242,35 @@ void ModelHelper::prepareForIndexedRendering(map<string, Group*>* groups)
 		// remap skinning
 		auto skinning = group->getSkinning();
 		if (skinning != nullptr) {
-			prepareForIndexedRendering(skinning, &vertexMapping, preparedIndices);
+			prepareForIndexedRendering(skinning, vertexMapping, preparedIndices);
 		}
-		group->setVertices(&indexedVertices);
-		group->setNormals(&indexedNormals);
+		group->setVertices(indexedVertices);
+		group->setNormals(indexedNormals);
 		if (groupTextureCoordinates->size() > 0) {
-			group->setTextureCoordinates(&indexedTextureCoordinates);
+			group->setTextureCoordinates(indexedTextureCoordinates);
 		}
 		if (groupTangents != nullptr && groupBitangents != nullptr) {
-			group->setTangents(&indexedTangents);
-			group->setBitangents(&indexedBitangents);
+			group->setTangents(indexedTangents);
+			group->setBitangents(indexedBitangents);
 		}
 		// process sub groups
 		prepareForIndexedRendering(group->getSubGroups());
 	}
 }
 
-void ModelHelper::prepareForIndexedRendering(Skinning* skinning, vector<int32_t>* vertexMapping, int32_t vertices)
+void ModelHelper::prepareForIndexedRendering(Skinning* skinning, const vector<int32_t>& vertexMapping, int32_t vertices)
 {
 	auto originalVerticesJointsWeights = skinning->getVerticesJointsWeights();
 	vector<vector<JointWeight>> verticesJointsWeights;
 	verticesJointsWeights.resize(vertices);
 	for (auto i = 0; i < vertices; i++) {
-		auto vertexOriginalMappedToIdx = (*vertexMapping)[i];
+		auto vertexOriginalMappedToIdx = vertexMapping[i];
 		verticesJointsWeights[i].resize((*originalVerticesJointsWeights)[vertexOriginalMappedToIdx].size());
 		for (auto j = 0; j < verticesJointsWeights[i].size(); j++) {
 			verticesJointsWeights[i][j] = (*originalVerticesJointsWeights)[vertexOriginalMappedToIdx][j];
 		}
 	}
-	skinning->setVerticesJointsWeights(&verticesJointsWeights);
+	skinning->setVerticesJointsWeights(verticesJointsWeights);
 }
 
 void ModelHelper::setDiffuseMaskedTransparency(Model* model, bool maskedTransparency) {
@@ -403,12 +403,12 @@ Material* ModelHelper::cloneMaterial(Material* material) {
 
 void ModelHelper::cloneGroup(Group* sourceGroup, Model* targetModel, Group* targetParentGroup) {
 	auto clonedGroup = new Group(targetModel, targetParentGroup, sourceGroup->getId(), sourceGroup->getName());
-	clonedGroup->setVertices(sourceGroup->getVertices());
-	clonedGroup->setNormals(sourceGroup->getNormals());
-	clonedGroup->setTextureCoordinates(sourceGroup->getTextureCoordinates());
-	clonedGroup->setTangents(sourceGroup->getTangents());
-	clonedGroup->setBitangents(sourceGroup->getBitangents());
-	clonedGroup->setFacesEntities(sourceGroup->getFacesEntities());
+	clonedGroup->setVertices(*(sourceGroup->getVertices()));
+	clonedGroup->setNormals(*(sourceGroup->getNormals()));
+	clonedGroup->setTextureCoordinates(*(sourceGroup->getTextureCoordinates()));
+	clonedGroup->setTangents(*(sourceGroup->getTangents()));
+	clonedGroup->setBitangents(*(sourceGroup->getBitangents()));
+	clonedGroup->setFacesEntities(*(sourceGroup->getFacesEntities()));
 	clonedGroup->setJoint(false);
 	clonedGroup->getTransformationsMatrix().set(sourceGroup->getTransformationsMatrix());
 	for (auto& facesEntity: *clonedGroup->getFacesEntities()) {

--- a/src/tdme/engine/model/ModelHelper.h
+++ b/src/tdme/engine/model/ModelHelper.h
@@ -44,7 +44,7 @@ public:
 	 * @param normal face normal
 	 * @return computed face normal
 	 */
-	static void computeNormal(array<Vector3,3>* vertices, Vector3& normal);
+	static void computeNormal(const array<Vector3,3>& vertices, Vector3& normal);
 
 	/** 
 	 * Computes face normals for given face vertices
@@ -52,7 +52,7 @@ public:
 	 * @param vertices face vertices
 	 * @param normals computed face normals
 	 */
-	static void computeNormals(array<Vector3,3>* vertices, array<Vector3,3>* normals);
+	static void computeNormals(const array<Vector3,3>& vertices, array<Vector3,3>& normals);
 
 	/** 
 	 * Create normal tangents and bitangents for groups with normal mapping
@@ -79,7 +79,7 @@ private:
 	 * Prepares this group for indexed rendering
 	 * @param groups groups
 	 */
-	static void prepareForIndexedRendering(map<string, Group*>* groups);
+	static void prepareForIndexedRendering(map<string, Group*>* groups); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Maps original vertices to new vertice mapping

--- a/src/tdme/engine/model/ModelHelper.h
+++ b/src/tdme/engine/model/ModelHelper.h
@@ -87,7 +87,7 @@ private:
 	 * @param vertexMapping vertice mapping / new vertex index to old vertex index
 	 * @param vertices vertice count
 	 */
-	static void prepareForIndexedRendering(Skinning* skinning, vector<int32_t>* vertexMapping, int32_t vertices);
+	static void prepareForIndexedRendering(Skinning* skinning, const vector<int32_t>& vertexMapping, int32_t vertices);
 
 public:
 

--- a/src/tdme/engine/model/Skinning.cpp
+++ b/src/tdme/engine/model/Skinning.cpp
@@ -38,11 +38,11 @@ vector<Joint>* Skinning::getJoints()
 	return &joints;
 }
 
-void Skinning::setJoints(const vector<Joint>* joints)
+void Skinning::setJoints(const vector<Joint>& joints)
 {
-	this->joints.resize(joints->size());
+	this->joints.resize(joints.size());
 	int i = 0;
-	for (auto& joint: *joints) {
+	for (auto& joint: joints) {
 		this->joints[i++] = joint;
 	}
 	setupJointsByName();
@@ -53,13 +53,13 @@ vector<vector<JointWeight>>* Skinning::getVerticesJointsWeights()
 	return &verticesJointsWeights;
 }
 
-void Skinning::setVerticesJointsWeights(const vector<vector<JointWeight>>* verticesJointsWeights)
+void Skinning::setVerticesJointsWeights(const vector<vector<JointWeight>>& verticesJointsWeights)
 {
-	this->verticesJointsWeights.resize(verticesJointsWeights->size());
-	for (auto i = 0; i < verticesJointsWeights->size(); i++) {
-		this->verticesJointsWeights[i].resize(verticesJointsWeights->at(i).size());
-		for (auto j = 0; j < verticesJointsWeights->at(i).size(); j++) {
-			this->verticesJointsWeights[i][j] = (*verticesJointsWeights)[i][j];
+	this->verticesJointsWeights.resize(verticesJointsWeights.size());
+	for (auto i = 0; i < verticesJointsWeights.size(); i++) {
+		this->verticesJointsWeights[i].resize(verticesJointsWeights.at(i).size());
+		for (auto j = 0; j < verticesJointsWeights.at(i).size(); j++) {
+			this->verticesJointsWeights[i][j] = verticesJointsWeights[i][j];
 		}
 	}
 }

--- a/src/tdme/engine/model/Skinning.h
+++ b/src/tdme/engine/model/Skinning.h
@@ -53,7 +53,7 @@ public:
 	 * Set up joints
 	 * @param joints joints
 	 */
-	void setJoints(const vector<Joint>* joints);
+	void setJoints(const vector<Joint>& joints);
 
 	/** 
 	 * @return all vertex joints
@@ -64,7 +64,7 @@ public:
 	 * Sets up vertices joints weights 
 	 * @param verticesJointsWeights verticesJointsWeights
 	 */
-	void setVerticesJointsWeights(const vector<vector<JointWeight>>* verticesJointsWeights);
+	void setVerticesJointsWeights(const vector<vector<JointWeight>>& verticesJointsWeights);
 
 	/** 
 	 * Get joint by name

--- a/src/tdme/engine/physics/World.h
+++ b/src/tdme/engine/physics/World.h
@@ -2,6 +2,8 @@
 
 #include <map>
 #include <string>
+#include <vector>
+
 
 #include <ext/reactphysics3d/src/engine/DynamicsWorld.h>
 

--- a/src/tdme/engine/primitives/PrimitiveModel.cpp
+++ b/src/tdme/engine/primitives/PrimitiveModel.cpp
@@ -113,9 +113,9 @@ Model* PrimitiveModel::createBoundingBoxModel(BoundingBox* boundingBox, const st
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
 	// setup group vertex data
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	// determine features
 	group->determineFeatures();
 	// register group
@@ -183,9 +183,9 @@ Model* PrimitiveModel::createOrientedBoundingBoxModel(OrientedBoundingBox* orien
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
 	// setup group vertex data
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	// determine features
 	group->determineFeatures();
 	// register group
@@ -276,9 +276,9 @@ Model* PrimitiveModel::createSphereModel(Sphere* sphere, const string& id, int32
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
 	// setup group vertex data
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	// determine features
 	group->determineFeatures();
 	// register group
@@ -407,9 +407,9 @@ Model* PrimitiveModel::createCapsuleModel(Capsule* capsule, const string& id, in
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
 	// setup group vertex data
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	// determine features
 	group->determineFeatures();
 	// register group

--- a/src/tdme/engine/primitives/PrimitiveModel.cpp
+++ b/src/tdme/engine/primitives/PrimitiveModel.cpp
@@ -243,7 +243,7 @@ Model* PrimitiveModel::createSphereModel(Sphere* sphere, const string& id, int32
 					vertices.at(vi2)
 				};
 				array<Vector3, 3> faceNormals;
-				ModelHelper::computeNormals(&faceVertices, &faceNormals);
+				ModelHelper::computeNormals(faceVertices, faceNormals);
 				for (auto& normal : faceNormals) {
 					normals.push_back(normal);
 				}
@@ -260,7 +260,7 @@ Model* PrimitiveModel::createSphereModel(Sphere* sphere, const string& id, int32
 					vertices.at(vi2)
 				};
 				array<Vector3, 3> faceNormals;
-				ModelHelper::computeNormals(&faceVertices, &faceNormals);
+				ModelHelper::computeNormals(faceVertices, faceNormals);
 				for (auto& normal : faceNormals) {
 					normals.push_back(normal);
 				}
@@ -375,7 +375,7 @@ Model* PrimitiveModel::createCapsuleModel(Capsule* capsule, const string& id, in
 					vertices.at(vi2)
 				};
 				array<Vector3, 3> faceNormals;
-				ModelHelper::computeNormals(&faceVertices, &faceNormals);
+				ModelHelper::computeNormals(faceVertices, faceNormals);
 				for (auto& normal : faceNormals) {
 					normals.push_back(normal);
 				}
@@ -391,7 +391,7 @@ Model* PrimitiveModel::createCapsuleModel(Capsule* capsule, const string& id, in
 					vertices.at(vi2)
 				};
 				array<Vector3, 3> faceNormals;
-				ModelHelper::computeNormals(&faceVertices, &faceNormals);
+				ModelHelper::computeNormals(faceVertices, faceNormals);
 				for (auto& normal : faceNormals) {
 					normals.push_back(normal);
 				}

--- a/src/tdme/engine/primitives/PrimitiveModel.h
+++ b/src/tdme/engine/primitives/PrimitiveModel.h
@@ -77,7 +77,7 @@ private:
 	 * @param groups groups
 	 * @param material material
 	 */
-	static void setupConvexMeshMaterial(map<string, Group*>* groups, Material* material);
+	static void setupConvexMeshMaterial(map<string, Group*>* groups, Material* material); // TODO: std container: maybe use call by reference
 
 public:
 	/** 

--- a/src/tdme/engine/primitives/Sphere.cpp
+++ b/src/tdme/engine/primitives/Sphere.cpp
@@ -1,14 +1,11 @@
 #include <tdme/engine/primitives/Sphere.h>
 
-#include <vector>
-
 #include <ext/reactphysics3d/src/collision/shapes/SphereShape.h>
 
 #include <tdme/math/Math.h>
 #include <tdme/math/Vector3.h>
 
 using std::to_string;
-using std::vector;
 
 using tdme::engine::primitives::Sphere;
 using tdme::math::Math;

--- a/src/tdme/engine/primitives/Triangle.cpp
+++ b/src/tdme/engine/primitives/Triangle.cpp
@@ -1,11 +1,7 @@
 #include <tdme/engine/primitives/Triangle.h>
 
-#include <vector>
-
 #include <tdme/math/Math.h>
 #include <tdme/math/Vector3.h>
-
-using std::vector;
 
 using tdme::engine::primitives::Triangle;
 

--- a/src/tdme/engine/subsystems/manager/TextureManager.h
+++ b/src/tdme/engine/subsystems/manager/TextureManager.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <map>

--- a/src/tdme/engine/subsystems/manager/VBOManager.cpp
+++ b/src/tdme/engine/subsystems/manager/VBOManager.cpp
@@ -39,7 +39,7 @@ VBOManager_VBOManaged* VBOManager::addVBO(const string& vboId, int32_t ids)
 	// create vertex buffer objects
 	auto vboIds = renderer->createBufferObjects(ids);
 	// create managed texture
-	auto vboManaged = new VBOManager_VBOManaged(vboId, &vboIds);
+	auto vboManaged = new VBOManager_VBOManaged(vboId, vboIds);
 	// add it to our textures
 	vboManaged->incrementReferenceCounter();
 	vbos[vboManaged->getId()] = vboManaged;
@@ -55,7 +55,7 @@ void VBOManager::removeVBO(const string& vboId)
 		if (vboManaged->decrementReferenceCounter()) {
 			auto vboIds = vboManaged->getVBOGlIds();
 			// delete vbos from open gl
-			renderer->disposeBufferObjects(vboIds);
+			renderer->disposeBufferObjects(*vboIds);
 			// remove from our list
 			vbos.erase(vboManagedIt);
 			delete vboManaged;

--- a/src/tdme/engine/subsystems/manager/VBOManager_VBOManaged.cpp
+++ b/src/tdme/engine/subsystems/manager/VBOManager_VBOManaged.cpp
@@ -9,10 +9,10 @@ using std::string;
 using tdme::engine::subsystems::manager::VBOManager_VBOManaged;
 using tdme::engine::subsystems::manager::VBOManager;
 
-VBOManager_VBOManaged::VBOManager_VBOManaged(const string& id, vector<int32_t>* vboGlIds)
+VBOManager_VBOManaged::VBOManager_VBOManaged(const string& id, vector<int32_t>& vboGlIds)
 {
 	this->id = id;
-	this->vboGlIds = *vboGlIds;
+	this->vboGlIds = vboGlIds;
 	this->referenceCounter = 0;
 }
 

--- a/src/tdme/engine/subsystems/manager/VBOManager_VBOManaged.h
+++ b/src/tdme/engine/subsystems/manager/VBOManager_VBOManaged.h
@@ -63,5 +63,5 @@ public:
 	virtual bool isUploaded();
 
 private:
-	VBOManager_VBOManaged(const string& id, vector<int32_t>* vboGlIds);
+	VBOManager_VBOManaged(const string& id, vector<int32_t>& vboGlIds);
 };

--- a/src/tdme/engine/subsystems/renderer/GL2Renderer.cpp
+++ b/src/tdme/engine/subsystems/renderer/GL2Renderer.cpp
@@ -621,9 +621,9 @@ void GL2Renderer::unbindBufferObjects()
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
-void GL2Renderer::disposeBufferObjects(vector<int32_t>* bufferObjectIds)
+void GL2Renderer::disposeBufferObjects(vector<int32_t>& bufferObjectIds)
 {
-	glDeleteBuffers(bufferObjectIds->size(), (const uint32_t*)bufferObjectIds->data());
+	glDeleteBuffers(bufferObjectIds.size(), (const uint32_t*)bufferObjectIds.data());
 }
 
 int32_t GL2Renderer::getTextureUnit()

--- a/src/tdme/engine/subsystems/renderer/GL2Renderer.h
+++ b/src/tdme/engine/subsystems/renderer/GL2Renderer.h
@@ -128,7 +128,7 @@ public:
 	void drawTrianglesFromBufferObjects(int32_t triangles, int32_t trianglesOffset) override;
 	void drawPointsFromBufferObjects(int32_t points, int32_t pointsOffset) override;
 	void unbindBufferObjects() override;
-	void disposeBufferObjects(vector<int32_t>* bufferObjectIds) override;
+	void disposeBufferObjects(vector<int32_t>& bufferObjectIds) override;
 	int32_t getTextureUnit() override;
 	void setTextureUnit(int32_t textureUnit) override;
 	float readPixelDepth(int32_t x, int32_t y) override;

--- a/src/tdme/engine/subsystems/renderer/GL3Renderer.cpp
+++ b/src/tdme/engine/subsystems/renderer/GL3Renderer.cpp
@@ -651,9 +651,9 @@ void GL3Renderer::unbindBufferObjects()
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ID_NONE);
 }
 
-void GL3Renderer::disposeBufferObjects(vector<int32_t>* bufferObjectIds)
+void GL3Renderer::disposeBufferObjects(vector<int32_t>& bufferObjectIds)
 {
-	glDeleteBuffers(bufferObjectIds->size(), (const uint32_t*)bufferObjectIds->data());
+	glDeleteBuffers(bufferObjectIds.size(), (const uint32_t*)bufferObjectIds.data());
 }
 
 int32_t GL3Renderer::getTextureUnit()

--- a/src/tdme/engine/subsystems/renderer/GL3Renderer.h
+++ b/src/tdme/engine/subsystems/renderer/GL3Renderer.h
@@ -107,7 +107,7 @@ public:
 	void drawTrianglesFromBufferObjects(int32_t triangles, int32_t trianglesOffset) override;
 	void drawPointsFromBufferObjects(int32_t points, int32_t pointsOffset) override;
 	void unbindBufferObjects() override;
-	void disposeBufferObjects(vector<int32_t>* bufferObjectIds) override;
+	void disposeBufferObjects(vector<int32_t>& bufferObjectIds) override;
 	int32_t getTextureUnit() override;
 
 	/** 

--- a/src/tdme/engine/subsystems/renderer/GLES2Renderer.cpp
+++ b/src/tdme/engine/subsystems/renderer/GLES2Renderer.cpp
@@ -588,9 +588,9 @@ void GLES2Renderer::unbindBufferObjects()
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }
 
-void GLES2Renderer::disposeBufferObjects(vector<int32_t>* bufferObjectIds)
+void GLES2Renderer::disposeBufferObjects(vector<int32_t>& bufferObjectIds)
 {
-	glDeleteBuffers(bufferObjectIds->size(), (const uint32_t*)bufferObjectIds->data());
+	glDeleteBuffers(bufferObjectIds.size(), (const uint32_t*)bufferObjectIds.data());
 }
 
 int32_t GLES2Renderer::getTextureUnit()

--- a/src/tdme/engine/subsystems/renderer/GLES2Renderer.h
+++ b/src/tdme/engine/subsystems/renderer/GLES2Renderer.h
@@ -103,7 +103,7 @@ public:
 	void drawTrianglesFromBufferObjects(int32_t triangles, int32_t trianglesOffset) override;
 	void drawPointsFromBufferObjects(int32_t points, int32_t pointsOffset) override;
 	void unbindBufferObjects() override;
-	void disposeBufferObjects(vector<int32_t>* bufferObjectIds) override;
+	void disposeBufferObjects(vector<int32_t>& bufferObjectIds) override;
 	int32_t getTextureUnit() override;
 	void setTextureUnit(int32_t textureUnit) override;
 	float readPixelDepth(int32_t x, int32_t y) override;

--- a/src/tdme/engine/subsystems/renderer/GLRenderer.h
+++ b/src/tdme/engine/subsystems/renderer/GLRenderer.h
@@ -596,7 +596,7 @@ public:
 	 * Disposes a frame buffer object
 	 * @param bufferObjectIds frame buffer id
 	 */
-	virtual void disposeBufferObjects(vector<int32_t>* bufferObjectIds) = 0;
+	virtual void disposeBufferObjects(vector<int32_t>& bufferObjectIds) = 0;
 
 	/** 
 	 * @return active texture unit

--- a/src/tdme/engine/subsystems/rendering/ModelUtilitiesInternal.cpp
+++ b/src/tdme/engine/subsystems/rendering/ModelUtilitiesInternal.cpp
@@ -68,7 +68,7 @@ BoundingBox* ModelUtilitiesInternal::createBoundingBox(Object3DModelInternal* ob
 		Matrix4x4& parentTransformationsMatrix = object3DModelInternal->getModel()->getImportTransformationsMatrix();
 		parentTransformationsMatrix.multiply(object3DModelInternal->getTransformationsMatrix());
 		object3DModelInternal->computeTransformationsMatrices(model->getSubGroups(), parentTransformationsMatrix, &animationState, 0);
-		Object3DGroup::computeTransformations(&object3DModelInternal->object3dGroups);
+		Object3DGroup::computeTransformations(object3DModelInternal->object3dGroups);
 		// parse through object groups to determine min, max
 		for (auto object3DGroup : object3DModelInternal->object3dGroups) {
 			for (auto vertex : *object3DGroup->mesh->vertices) {

--- a/src/tdme/engine/subsystems/rendering/ModelUtilitiesInternal.h
+++ b/src/tdme/engine/subsystems/rendering/ModelUtilitiesInternal.h
@@ -59,7 +59,7 @@ private:
 	 * Invert normals recursive
 	 * @param groups groups
 	 */
-	static void invertNormals(map<string, Group*>* groups);
+	static void invertNormals(map<string, Group*>* groups); // TODO: std container: maybe use call by reference
 
 public:
 

--- a/src/tdme/engine/subsystems/rendering/Object3DBase.cpp
+++ b/src/tdme/engine/subsystems/rendering/Object3DBase.cpp
@@ -67,7 +67,7 @@ Object3DBase::Object3DBase(Model* model, bool useMeshManager, Engine::AnimationP
 	if (model->hasSkinning() == true) {
 		hasSkinning = true;
 		skinningGroups.resize(determineSkinnedGroupCount(model->getSubGroups()));
-		determineSkinnedGroups(model->getSubGroups(), &skinningGroups, 0);
+		determineSkinnedGroups(model->getSubGroups(), skinningGroups, 0);
 		skinningGroupsMatrices.resize(skinningGroups.size());
 		for (auto i = 0; i < skinningGroups.size(); i++) {
 			createTransformationsMatrices(&skinningGroupsMatrices[i], model->getSubGroups());
@@ -80,9 +80,9 @@ Object3DBase::Object3DBase(Model* model, bool useMeshManager, Engine::AnimationP
 	// calculate transformations matrices
 	computeTransformationsMatrices(model->getSubGroups(), model->getImportTransformationsMatrix(), &baseAnimation, 0);
 	// object 3d groups
-	Object3DGroup::createGroups(this, useMeshManager, animationProcessingTarget, &object3dGroups);
+	Object3DGroup::createGroups(this, useMeshManager, animationProcessingTarget, object3dGroups);
 	// do initial transformations if doing CPU no rendering for deriving bounding boxes and such
-	if (animationProcessingTarget == Engine::AnimationProcessingTarget::CPU_NORENDERING) Object3DGroup::computeTransformations(&object3dGroups);
+	if (animationProcessingTarget == Engine::AnimationProcessingTarget::CPU_NORENDERING) Object3DGroup::computeTransformations(object3dGroups);
 	// reset animation
 	setAnimation(Model::ANIMATIONSETUP_DEFAULT);
 }
@@ -350,7 +350,7 @@ void Object3DBase::computeTransformations()
 		// calculate transformations matrices
 		computeTransformationsMatrices(model->getSubGroups(), parentTransformationsMatrix, &baseAnimation, 0);
 		// do transformations in group render data
-		Object3DGroup::computeTransformations(&object3dGroups);
+		Object3DGroup::computeTransformations(object3dGroups);
 	} else
 	if (animationProcessingTarget == Engine::AnimationProcessingTarget::CPU_NORENDERING) {
 		// set up parent transformations matrix
@@ -362,7 +362,7 @@ void Object3DBase::computeTransformations()
 		// calculate transformations matrices
 		computeTransformationsMatrices(model->getSubGroups(), parentTransformationsMatrix, &baseAnimation, 0);
 		// do transformations in group render data
-		Object3DGroup::computeTransformations(&object3dGroups);
+		Object3DGroup::computeTransformations(object3dGroups);
 	}
 }
 
@@ -445,14 +445,14 @@ int32_t Object3DBase::determineSkinnedGroupCount(map<string, Group*>* groups, in
 	return count;
 }
 
-int32_t Object3DBase::determineSkinnedGroups(map<string, Group*>* groups, vector<Group*>* skinningGroups, int32_t idx)
+int32_t Object3DBase::determineSkinnedGroups(map<string, Group*>* groups, vector<Group*>& skinningGroups, int32_t idx)
 {
 	// iterate through groups
 	for (auto it: *groups) {
 		Group* group = it.second;
 		// fetch skinning groups
 		if (group->getSkinning() != nullptr) {
-			(*skinningGroups)[idx++] = group;
+			skinningGroups[idx++] = group;
 		}
 		// calculate sub groups
 		auto subGroups = group->getSubGroups();

--- a/src/tdme/engine/subsystems/rendering/Object3DBase.h
+++ b/src/tdme/engine/subsystems/rendering/Object3DBase.h
@@ -49,14 +49,14 @@ private:
 	 * Determine skinned group count
 	 * @param groups groups
 	 */
-	int32_t determineSkinnedGroupCount(map<string, Group*>* groups);
+	int32_t determineSkinnedGroupCount(map<string, Group*>* groups); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Determine skinned group count
 	 * @param map* groups
 	 * @param count current count
 	 */
-	int32_t determineSkinnedGroupCount(map<string, Group*>*, int32_t count);
+	int32_t determineSkinnedGroupCount(map<string, Group*>*, int32_t count); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Determine skinned groups
@@ -64,7 +64,7 @@ private:
 	 * @param skinningGroups skinning groups
 	 * @param idx idx
 	 */
-	int32_t determineSkinnedGroups(map<string, Group*>*, vector<Group*>* skinningGroups, int32_t idx);
+	int32_t determineSkinnedGroups(map<string, Group*>*, vector<Group*>& skinningGroups, int32_t idx); // TODO: std container: maybe use call by reference
 
 
 protected:
@@ -86,7 +86,7 @@ protected:
 	 * @param matrices matrices
 	 * @param groups groups
 	 */
-	virtual void createTransformationsMatrices(map<string, Matrix4x4*>* matrices, map<string, Group*>* groups);
+	virtual void createTransformationsMatrices(map<string, Matrix4x4*>* matrices, map<string, Group*>* groups); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Calculates all groups transformation matrices
@@ -95,7 +95,7 @@ protected:
 	 * @param animationState animation state
 	 * @param depth depth
 	 */
-	virtual void computeTransformationsMatrices(map<string, Group*>* groups, Matrix4x4& parentTransformationsMatrix, AnimationState* animationState, int32_t depth);
+	virtual void computeTransformationsMatrices(map<string, Group*>* groups, Matrix4x4& parentTransformationsMatrix, AnimationState* animationState, int32_t depth); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Get skinning groups matrices

--- a/src/tdme/engine/subsystems/rendering/Object3DGroup.cpp
+++ b/src/tdme/engine/subsystems/rendering/Object3DGroup.cpp
@@ -60,13 +60,13 @@ Object3DGroup::~Object3DGroup()
 	delete renderer;
 }
 
-void Object3DGroup::createGroups(Object3DBase* object, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>* object3DGroups)
+void Object3DGroup::createGroups(Object3DBase* object, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>& object3DGroups)
 {
 	auto model = object->getModel();
 	createGroups(object, model->getSubGroups(), model->hasAnimations(), useMeshManager, animationProcessingTarget, object3DGroups);
 }
 
-void Object3DGroup::createGroups(Object3DBase* object3D, map<string, Group*>* groups, bool animated, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>* object3DGroups)
+void Object3DGroup::createGroups(Object3DBase* object3D, map<string, Group*>* groups, bool animated, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>& object3DGroups)
 {
 	for (auto it: *groups) {
 		Group* group = it.second;
@@ -81,7 +81,7 @@ void Object3DGroup::createGroups(Object3DBase* object3D, map<string, Group*>* gr
 			// create group render data
 			auto object3DGroup = new Object3DGroup();
 			// add it to group render data list
-			object3DGroups->push_back(object3DGroup);
+			object3DGroups.push_back(object3DGroup);
 			// determine mesh id
 			object3DGroup->id =
 				group->getModel()->getId() +
@@ -144,9 +144,9 @@ void Object3DGroup::createGroups(Object3DBase* object3D, map<string, Group*>* gr
 	}
 }
 
-void Object3DGroup::computeTransformations(vector<Object3DGroup*>* object3DGroups)
+void Object3DGroup::computeTransformations(vector<Object3DGroup*>& object3DGroups)
 {
-	for (auto object3DGroup : *object3DGroups) {
+	for (auto object3DGroup : object3DGroups) {
 		object3DGroup->mesh->computeTransformations();
 	}
 }

--- a/src/tdme/engine/subsystems/rendering/Object3DGroup.h
+++ b/src/tdme/engine/subsystems/rendering/Object3DGroup.h
@@ -74,13 +74,13 @@ private:
 	 * @param object3DGroups object 3d groups array
 	 * @return object 3d group
 	 */
-	static void createGroups(Object3DBase* object, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>* object3DGroups);
+	static void createGroups(Object3DBase* object, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>& object3DGroups);
 
 	/** 
 	 * Applies transformations to meshes for given object 3d groups
 	 * @param object3DGroups group render data list
 	 */
-	static void computeTransformations(vector<Object3DGroup*>* object3DGroups);
+	static void computeTransformations(vector<Object3DGroup*>& object3DGroups);
 
 	/** 
 	 * Set up textures for given object3d group and faces entity
@@ -99,7 +99,7 @@ private:
 	 * @param animationProcessingTarget animation processing target
 	 * @param object3DGroups object 3D groups
 	 */
-	static void createGroups(Object3DBase* object3D, map<string, Group*>* groups, bool animated, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>* object3DGroups);
+	static void createGroups(Object3DBase* object3D, map<string, Group*>* groups, bool animated, bool useMeshManager, Engine::AnimationProcessingTarget animationProcessingTarget, vector<Object3DGroup*>& object3DGroups); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Dispose

--- a/src/tdme/engine/subsystems/rendering/Object3DGroupMesh.cpp
+++ b/src/tdme/engine/subsystems/rendering/Object3DGroupMesh.cpp
@@ -2,7 +2,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 #include <tdme/utils/ByteBuffer.h>
 #include <tdme/utils/FloatBuffer.h>
@@ -26,7 +25,6 @@
 #include <tdme/utils/Console.h>
 
 using std::map;
-using std::vector;
 using std::string;
 
 using tdme::engine::subsystems::rendering::Object3DGroupMesh;

--- a/src/tdme/engine/subsystems/rendering/Object3DGroupMesh.h
+++ b/src/tdme/engine/subsystems/rendering/Object3DGroupMesh.h
@@ -80,7 +80,7 @@ private:
 	 * @param skinningMatrices skinning matrices 
 	 * @return object 3d group mesh
 	 */
-	static Object3DGroupMesh* createMesh(Object3DGroupVBORenderer* object3DVBOGroupRenderer, Engine::AnimationProcessingTarget animationProcessingTarget, Group* group, map<string, Matrix4x4*>* transformationMatrices,map<string, Matrix4x4*>* skinningMatrices);
+	static Object3DGroupMesh* createMesh(Object3DGroupVBORenderer* object3DVBOGroupRenderer, Engine::AnimationProcessingTarget animationProcessingTarget, Group* group, map<string, Matrix4x4*>* transformationMatrices,map<string, Matrix4x4*>* skinningMatrices); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Computes mesh transformations

--- a/src/tdme/engine/subsystems/rendering/Object3DGroupVBORenderer.cpp
+++ b/src/tdme/engine/subsystems/rendering/Object3DGroupVBORenderer.cpp
@@ -1,7 +1,5 @@
 #include <tdme/engine/subsystems/rendering/Object3DGroupVBORenderer.h>
 
-#include <vector>
-
 #include <tdme/utils/FloatBuffer.h>
 #include <tdme/utils/ShortBuffer.h>
 #include <tdme/engine/Engine.h>
@@ -14,8 +12,6 @@
 #include <tdme/engine/subsystems/rendering/Object3DVBORenderer.h>
 #include <tdme/engine/subsystems/renderer/GLRenderer.h>
 #include <tdme/math/Vector3.h>
-
-using std::vector;
 
 using tdme::engine::subsystems::rendering::Object3DGroupVBORenderer;
 using tdme::utils::FloatBuffer;

--- a/src/tdme/engine/subsystems/rendering/TransparentRenderFacesGroup.cpp
+++ b/src/tdme/engine/subsystems/rendering/TransparentRenderFacesGroup.cpp
@@ -1,7 +1,6 @@
 #include <tdme/engine/subsystems/rendering/TransparentRenderFacesGroup.h>
 
 #include <string>
-#include <vector>
 
 #include <tdme/engine/model/Color4.h>
 #include <tdme/engine/model/Material.h>
@@ -13,7 +12,6 @@
 #include <tdme/math/Matrix4x4.h>
 #include <tdme/utils/Console.h>
 
-using std::vector;
 using std::string;
 using std::to_string;
 

--- a/src/tdme/gui/elements/GUIDropDownController.cpp
+++ b/src/tdme/gui/elements/GUIDropDownController.cpp
@@ -1,7 +1,6 @@
 #include <tdme/gui/elements/GUIDropDownController.h>
 
 #include <string>
-#include <vector>
 
 #include <tdme/gui/GUI.h>
 #include <tdme/gui/elements/GUIDropDownOptionController.h>
@@ -17,7 +16,6 @@
 #include <tdme/gui/nodes/GUIScreenNode.h>
 #include <tdme/utils/MutableString.h>
 
-using std::vector;
 using std::string;
 
 using tdme::gui::elements::GUIDropDownController;
@@ -102,7 +100,7 @@ bool GUIDropDownController::isOpen()
 
 void GUIDropDownController::unselect()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -124,7 +122,7 @@ void GUIDropDownController::toggleOpenState()
 void GUIDropDownController::determineDropDownOptionControllers()
 {
 	dropDownOptionControllers.clear();
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();

--- a/src/tdme/gui/elements/GUISelectBoxController.cpp
+++ b/src/tdme/gui/elements/GUISelectBoxController.cpp
@@ -71,7 +71,7 @@ void GUISelectBoxController::postLayout()
 
 void GUISelectBoxController::unselect()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -84,7 +84,7 @@ void GUISelectBoxController::unselect()
 void GUISelectBoxController::determineSelectBoxOptionControllers()
 {
 	selectBoxOptionControllers.clear();
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();

--- a/src/tdme/gui/elements/GUISelectBoxMultipleController.cpp
+++ b/src/tdme/gui/elements/GUISelectBoxMultipleController.cpp
@@ -1,7 +1,5 @@
 #include <tdme/gui/elements/GUISelectBoxMultipleController.h>
 
-#include <vector>
-
 #include <tdme/gui/GUI.h>
 #include <tdme/gui/elements/GUISelectBoxMultipleOptionController.h>
 #include <tdme/gui/events/GUIKeyboardEvent_Type.h>
@@ -15,8 +13,6 @@
 #include <tdme/gui/nodes/GUIParentNode.h>
 #include <tdme/gui/nodes/GUIScreenNode.h>
 #include <tdme/utils/MutableString.h>
-
-using std::vector;
 
 using tdme::gui::elements::GUISelectBoxMultipleController;
 using tdme::gui::GUI;
@@ -81,7 +77,7 @@ void GUISelectBoxMultipleController::postLayout()
 
 void GUISelectBoxMultipleController::unselect()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -93,7 +89,7 @@ void GUISelectBoxMultipleController::unselect()
 
 void GUISelectBoxMultipleController::unfocus()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -106,7 +102,7 @@ void GUISelectBoxMultipleController::unfocus()
 void GUISelectBoxMultipleController::determineSelectBoxMultipleOptionControllers()
 {
 	selectBoxMultipleOptionControllers.clear();
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();

--- a/src/tdme/gui/elements/GUITabsController.cpp
+++ b/src/tdme/gui/elements/GUITabsController.cpp
@@ -1,15 +1,11 @@
 #include <tdme/gui/elements/GUITabsController.h>
 
-#include <vector>
-
 #include <tdme/gui/elements/GUITabContentController.h>
 #include <tdme/gui/elements/GUITabController.h>
 #include <tdme/gui/nodes/GUINode.h>
 #include <tdme/gui/nodes/GUINodeController.h>
 #include <tdme/gui/nodes/GUIParentNode.h>
 #include <tdme/utils/MutableString.h>
-
-using std::vector;
 
 using tdme::gui::elements::GUITabsController;
 using tdme::gui::elements::GUITabContentController;
@@ -40,7 +36,7 @@ void GUITabsController::setDisabled(bool disabled)
 
 void GUITabsController::initialize()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -66,7 +62,7 @@ void GUITabsController::postLayout()
 
 void GUITabsController::unselect()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -84,7 +80,7 @@ void GUITabsController::setTabContentSelected(const string& id)
 {
 	MutableString tabContentNodeId;
 	tabContentNodeId.set(id + "-content");
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();

--- a/src/tdme/gui/elements/GUITabsHeaderController.cpp
+++ b/src/tdme/gui/elements/GUITabsHeaderController.cpp
@@ -62,7 +62,7 @@ bool GUITabsHeaderController::hasFocus()
 
 void GUITabsHeaderController::unselect()
 {
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();
@@ -79,7 +79,7 @@ void GUITabsHeaderController::unselect()
 void GUITabsHeaderController::determineTabControllers()
 {
 	tabControllers.clear();
-	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(&childControllerNodes);
+	(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		auto childController = childControllerNode->getController();

--- a/src/tdme/gui/nodes/GUIElementNode.h
+++ b/src/tdme/gui/nodes/GUIElementNode.h
@@ -2,7 +2,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 #include <tdme/tdme.h>
 #include <tdme/gui/fwd-tdme.h>
@@ -13,7 +12,6 @@
 
 using std::set;
 using std::string;
-using std::vector;
 
 using tdme::gui::nodes::GUIParentNode;
 using tdme::gui::events::GUIKeyboardEvent;

--- a/src/tdme/gui/nodes/GUIHorizontalScrollbarInternalNode.h
+++ b/src/tdme/gui/nodes/GUIHorizontalScrollbarInternalNode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <tdme/tdme.h>
 #include <tdme/gui/nodes/fwd-tdme.h>
@@ -10,6 +11,7 @@
 #include <tdme/gui/nodes/GUINode.h>
 
 using std::string;
+using std::vector;
 
 using tdme::gui::nodes::GUINode;
 using tdme::gui::nodes::GUIColor;

--- a/src/tdme/gui/nodes/GUINode.h
+++ b/src/tdme/gui/nodes/GUINode.h
@@ -398,7 +398,7 @@ public:
 	 * @param event event
 	 * @param eventNodeIds event node ids
 	 */
-	virtual void determineMouseEventNodes(GUIMouseEvent* event, set<string>& eventNodeIds);
+	virtual void determineMouseEventNodes(GUIMouseEvent* event, set<string>& eventNodeIds); // TODO: std container: maybe use call by reference
 
 	/**
 	 * Handle keyboard event

--- a/src/tdme/gui/nodes/GUIPanelNode.cpp
+++ b/src/tdme/gui/nodes/GUIPanelNode.cpp
@@ -2,13 +2,11 @@
 
 #include <string>
 #include <set>
-#include <vector>
 
 #include <tdme/gui/events/GUIMouseEvent.h>
 
 using std::set;
 using std::string;
-using std::vector;
 
 using tdme::gui::nodes::GUIPanelNode;
 using tdme::gui::events::GUIMouseEvent;

--- a/src/tdme/gui/nodes/GUIPanelNode.h
+++ b/src/tdme/gui/nodes/GUIPanelNode.h
@@ -2,7 +2,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 #include <tdme/gui/fwd-tdme.h>
 #include <tdme/gui/events/fwd-tdme.h>
@@ -11,7 +10,6 @@
 
 using std::set;
 using std::string;
-using std::vector;
 
 using tdme::gui::nodes::GUILayoutNode;
 using tdme::gui::events::GUIKeyboardEvent;

--- a/src/tdme/gui/nodes/GUIParentNode.cpp
+++ b/src/tdme/gui/nodes/GUIParentNode.cpp
@@ -294,12 +294,12 @@ void GUIParentNode::computeVerticalChildrenAlignment()
 	}
 }
 
-void GUIParentNode::getChildControllerNodesInternal(vector<GUINode*>* childControllerNodes)
+void GUIParentNode::getChildControllerNodesInternal(vector<GUINode*>& childControllerNodes)
 {
 	for (auto i = 0; i < subNodes.size(); i++) {
 		auto node = subNodes[i];
 		if (node->controller != nullptr) {
-			childControllerNodes->push_back(node);
+			childControllerNodes.push_back(node);
 		}
 		if (dynamic_cast< GUIParentNode* >(node) != nullptr) {
 			(dynamic_cast< GUIParentNode* >(node))->getChildControllerNodesInternal(childControllerNodes);
@@ -307,9 +307,9 @@ void GUIParentNode::getChildControllerNodesInternal(vector<GUINode*>* childContr
 	}
 }
 
-void GUIParentNode::getChildControllerNodes(vector<GUINode*>*childControllerNodes)
+void GUIParentNode::getChildControllerNodes(vector<GUINode*>& childControllerNodes)
 {
-	childControllerNodes->clear();
+	childControllerNodes.clear();
 	getChildControllerNodesInternal(childControllerNodes);
 }
 

--- a/src/tdme/gui/nodes/GUIParentNode.h
+++ b/src/tdme/gui/nodes/GUIParentNode.h
@@ -192,7 +192,8 @@ public:
 	 * Get child controller nodes
 	 * @param childControllerNodes child controller nodes
 	 */
-	virtual void getChildControllerNodes(vector<GUINode*>* childControllerNodes);
+	virtual void getChildControllerNodes(vector<GUINode*>& childControllerNodes);
+
 	void dispose() override;
 	void setConditionsMet() override;
 	void render(GUIRenderer* guiRenderer, vector<GUINode*>& floatingNodes) override;
@@ -204,7 +205,7 @@ private:
 	 * Get child controller nodes internal
 	 * @param childControllerNodes child controller nodes
 	 */
-	void getChildControllerNodesInternal(vector<GUINode*>* childControllerNodes);
+	void getChildControllerNodesInternal(vector<GUINode*>& childControllerNodes);
 
 	/**
 	 * Invalidate render caches

--- a/src/tdme/gui/nodes/GUIScreenNode.cpp
+++ b/src/tdme/gui/nodes/GUIScreenNode.cpp
@@ -189,7 +189,7 @@ void GUIScreenNode::layout()
 	for (auto i = 0; i < subNodes.size(); i++) {
 		subNodes[i]->layout();
 	}
-	getChildControllerNodes(&childControllerNodes);
+	getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto node = childControllerNodes[i];
 		auto controller = node->getController();
@@ -204,7 +204,7 @@ void GUIScreenNode::layout(GUINode* node)
 	if (dynamic_cast< GUIParentNode* >(node) != nullptr) {
 		auto parentNode = dynamic_cast< GUIParentNode* >(node);
 		parentNode->layoutSubNodes();
-		parentNode->getChildControllerNodes(&childControllerNodes);
+		parentNode->getChildControllerNodes(childControllerNodes);
 		for (auto i = 0; i < childControllerNodes.size(); i++) {
 			auto childNode = childControllerNodes[i];
 			auto controller = childNode->getController();
@@ -423,7 +423,7 @@ void GUIScreenNode::tick() {
 void GUIScreenNode::getValues(map<string, MutableString>& values)
 {
 	values.clear();
-	getChildControllerNodes(&childControllerNodes);
+	getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		if (dynamic_cast< GUIElementNode* >(childControllerNode) != nullptr == false)
@@ -444,7 +444,7 @@ void GUIScreenNode::getValues(map<string, MutableString>& values)
 
 void GUIScreenNode::setValues(const map<string, MutableString>& values)
 {
-	getChildControllerNodes(&childControllerNodes);
+	getChildControllerNodes(childControllerNodes);
 	for (auto i = 0; i < childControllerNodes.size(); i++) {
 		auto childControllerNode = childControllerNodes[i];
 		if (dynamic_cast< GUIElementNode* >(childControllerNode) != nullptr == false)

--- a/src/tdme/gui/renderer/GUIFont.cpp
+++ b/src/tdme/gui/renderer/GUIFont.cpp
@@ -53,7 +53,7 @@ GUIFont* GUIFont::parse(const string& pathName, const string& fileName) throw (F
 	int lineIdx = 0;
 	auto font = new GUIFont();
 	vector<string> lines;
-	FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, &lines);
+	FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, lines);
 	auto info = lines[lineIdx++];
 	auto common = lines[lineIdx++];
 	auto page = lines[lineIdx++];

--- a/src/tdme/network/udpserver/NIOUDPServerIOThread.h
+++ b/src/tdme/network/udpserver/NIOUDPServerIOThread.h
@@ -4,7 +4,6 @@
 
 #include <queue>
 #include <map>
-#include <set>
 #include <utility>
 
 #include <tdme/network/udpserver/fwd-tdme.h>

--- a/src/tdme/os/filesystem/FileSystemInterface.h
+++ b/src/tdme/os/filesystem/FileSystemInterface.h
@@ -56,16 +56,16 @@ struct tdme::os::filesystem::FileSystemInterface
 	 * @param content content vector
 	 * @throws FileSystemException
 	 */
-	virtual void getContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException) = 0;
+	virtual void getContent(const string& pathName, const string& fileName, vector<uint8_t>& content) throw (FileSystemException) = 0;
 
 	/** 
-	 * Get file content
+	 * Set file content
 	 * @param pathName path name
 	 * @param fileName file name
 	 * @param content content vector
 	 * @throws FileSystemException
 	 */
-	virtual void setContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException) = 0;
+	virtual void setContent(const string& pathName, const string& fileName, const vector<uint8_t>& content) throw (FileSystemException) = 0;
 
 	/**
 	 * Get file content as string array
@@ -74,7 +74,7 @@ struct tdme::os::filesystem::FileSystemInterface
 	 * @param content content vector
 	 * @throws FileSystemException
 	 */
-	virtual void getContentAsStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException) = 0;
+	virtual void getContentAsStringArray(const string& pathName, const string& fileName, vector<string>& content) throw (FileSystemException) = 0;
 
 	/**
 	 * Set file content as string array
@@ -84,7 +84,7 @@ struct tdme::os::filesystem::FileSystemInterface
 	 * @return byte array
 	 * @throws FileSystemException
 	 */
-	virtual void setContentFromStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException) = 0;
+	virtual void setContentFromStringArray(const string& pathName, const string& fileName, const vector<string>& content) throw (FileSystemException) = 0;
 
 	/**
 	 * List files for given path and filter by a file name filter if not null 
@@ -93,7 +93,7 @@ struct tdme::os::filesystem::FileSystemInterface
 	 * @param filter filter or null
 	 * @return file names 
 	 */
-	virtual void list(const string& pathName, vector<string>* files, FilenameFilter* filter = nullptr) throw (FileSystemException) = 0;
+	virtual void list(const string& pathName, vector<string>& files, FilenameFilter* filter = nullptr) throw (FileSystemException) = 0;
 
 	/**
 	 * Check if file is a path

--- a/src/tdme/os/filesystem/StandardFileSystem.cpp
+++ b/src/tdme/os/filesystem/StandardFileSystem.cpp
@@ -47,7 +47,7 @@ const string StandardFileSystem::getFileName(const string& pathName, const strin
 	return pathName + "/" + fileName;
 }
 
-void StandardFileSystem::list(const string& pathName, vector<string>* files, FilenameFilter* filter) throw (FileSystemException)
+void StandardFileSystem::list(const string& pathName, vector<string>& files, FilenameFilter* filter) throw (FileSystemException)
 {
 	DIR *dir;
 	struct dirent *dirent;
@@ -57,9 +57,9 @@ void StandardFileSystem::list(const string& pathName, vector<string>* files, Fil
 	while ((dirent = readdir(dir)) != NULL) {
 		string fileName = (dirent->d_name);
 		if (filter != nullptr && filter->accept(pathName, fileName) == false) continue;
-		files->push_back(fileName);
+		files.push_back(fileName);
 	}
-	sort(files->begin(), files->end());
+	sort(files.begin(), files.end());
 	closedir(dir);
 }
 
@@ -98,7 +98,7 @@ void StandardFileSystem::setContentFromString(const string& pathName, const stri
 	return;
 }
 
-void StandardFileSystem::getContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException)
+void StandardFileSystem::getContent(const string& pathName, const string& fileName, vector<uint8_t>& content) throw (FileSystemException)
 {
 	ifstream ifs(getFileName(pathName, fileName).c_str(), ifstream::binary);
 	if (ifs.is_open() == false) {
@@ -106,22 +106,22 @@ void StandardFileSystem::getContent(const string& pathName, const string& fileNa
 	}
 	ifs.seekg( 0, ios::end );
 	size_t size = ifs.tellg();
-	content->resize(size);
+	content.resize(size);
 	ifs.seekg(0, ios::beg);
-	ifs.read((char*)content->data(), size);
+	ifs.read((char*)content.data(), size);
 	ifs.close();
 }
 
-void StandardFileSystem::setContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException) {
+void StandardFileSystem::setContent(const string& pathName, const string& fileName, const vector<uint8_t>& content) throw (FileSystemException) {
 	ofstream ofs(getFileName(pathName, fileName).c_str(), ofstream::binary);
 	if (ofs.is_open() == false) {
 		throw FileSystemException("Unable to open file for writing(" + to_string(errno) + "): " + pathName + "/" + fileName);
 	}
-	ofs.write((char*)content->data(), content->size());
+	ofs.write((char*)content.data(), content.size());
 	ofs.close();
 }
 
-void StandardFileSystem::getContentAsStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException)
+void StandardFileSystem::getContentAsStringArray(const string& pathName, const string& fileName, vector<string>& content) throw (FileSystemException)
 {
 	ifstream ifs(getFileName(pathName, fileName).c_str());
 	if(ifs.is_open() == false) {
@@ -130,21 +130,21 @@ void StandardFileSystem::getContentAsStringArray(const string& pathName, const s
 
 	string line;
 	while (getline(ifs, line)) {
-		content->push_back((line));
+		content.push_back((line));
 	}
 
 	ifs.close();
 }
 
-void StandardFileSystem::setContentFromStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException)
+void StandardFileSystem::setContentFromStringArray(const string& pathName, const string& fileName, const vector<string>& content) throw (FileSystemException)
 {
 	ofstream ofs(getFileName(pathName, fileName).c_str());
 	if(ofs.is_open() == false) {
 		throw FileSystemException("Unable to open file for writing(" + to_string(errno) + "): " + pathName + "/" + fileName);
 	}
 
-	for (int i = 0; i < content->size(); i++) {
-		ofs << (content->at(i)) << "\n";
+	for (int i = 0; i < content.size(); i++) {
+		ofs << (content.at(i)) << "\n";
 	}
 
 	ofs.close();
@@ -246,7 +246,7 @@ void StandardFileSystem::createPath(const string& pathName) throw (FileSystemExc
 
 void StandardFileSystem::removePath(const string& pathName) throw (FileSystemException) {
 	vector<string> files;
-	list(pathName, &files, nullptr);
+	list(pathName, files, nullptr);
 	for (int i = 0; i < files.size(); i++) {
 		auto file = files[i];
 		if (file == "." || file == "..") {

--- a/src/tdme/os/filesystem/StandardFileSystem.h
+++ b/src/tdme/os/filesystem/StandardFileSystem.h
@@ -19,15 +19,15 @@ class tdme::os::filesystem::StandardFileSystem final
 
 public:
 	const string getFileName(const string& path, const string& fileName) throw (FileSystemException) override;
-	void list(const string& pathName, vector<string>* files, FilenameFilter* filter = nullptr) throw (FileSystemException) override;
+	void list(const string& pathName, vector<string>& files, FilenameFilter* filter = nullptr) throw (FileSystemException) override;
 	bool isPath(const string& pathName) throw (FileSystemException) override;
 	bool fileExists(const string& fileName) throw (FileSystemException) override;
 	const string getContentAsString(const string& pathName, const string& fileName) throw (FileSystemException) override;
 	void setContentFromString(const string& pathName, const string& fileName, const string& content) throw (FileSystemException) override;
-	void getContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException) override;
-	void setContent(const string& pathName, const string& fileName, vector<uint8_t>* content) throw (FileSystemException) override;
-	void getContentAsStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException) override;
-	void setContentFromStringArray(const string& pathName, const string& fileName, vector<string>* content) throw (FileSystemException) override;
+	void getContent(const string& pathName, const string& fileName, vector<uint8_t>& content) throw (FileSystemException) override;
+	void setContent(const string& pathName, const string& fileName, const vector<uint8_t>& content) throw (FileSystemException) override;
+	void getContentAsStringArray(const string& pathName, const string& fileName, vector<string>& content) throw (FileSystemException) override;
+	void setContentFromStringArray(const string& pathName, const string& fileName, const vector<string>& content) throw (FileSystemException) override;
 	const string getCanonicalPath(const string& pathName, const string& fileName) throw (FileSystemException) override;
 	const string getCurrentWorkingPathName() throw (FileSystemException) override;
 	const string getPathName(const string& fileName) throw (FileSystemException) override;

--- a/src/tdme/tests/EngineTest.cpp
+++ b/src/tdme/tests/EngineTest.cpp
@@ -127,10 +127,10 @@ Model* EngineTest::createWallModel()
 	groupFacesEntityFarPlane.setMaterial(wallMaterial);
 	groupFacesEntityFarPlane.setFaces(&facesFarPlane);
 	groupFacesEntities.push_back(groupFacesEntityFarPlane);
-	wallGroup->setVertices(&vertices);
-	wallGroup->setNormals(&normals);
-	wallGroup->setTextureCoordinates(&textureCoordinates);
-	wallGroup->setFacesEntities(&groupFacesEntities);
+	wallGroup->setVertices(vertices);
+	wallGroup->setNormals(normals);
+	wallGroup->setTextureCoordinates(textureCoordinates);
+	wallGroup->setFacesEntities(groupFacesEntities);
 	wallGroup->determineFeatures();
 	(*wall->getGroups())["wall"] = wallGroup;
 	(*wall->getSubGroups())["wall"] = wallGroup;

--- a/src/tdme/tools/cli/fixdoxygen-main.cpp
+++ b/src/tdme/tools/cli/fixdoxygen-main.cpp
@@ -38,7 +38,7 @@ void scanDir(const string& folder, vector<string>& totalFiles) {
 	ListFilter listFilter;
 	vector<string> files;
 
-	FileSystem::getInstance()->list(folder, &files, &listFilter);
+	FileSystem::getInstance()->list(folder, files, &listFilter);
 
 	for (auto fileName: files) {
 		if (StringUtils::endsWith(fileName, ".h") == true) {
@@ -51,7 +51,7 @@ void scanDir(const string& folder, vector<string>& totalFiles) {
 
 void processFile(const string& fileName) {
 	vector<string> fileContent;
-	FileSystem::getInstance()->getContentAsStringArray(".", fileName, &fileContent);
+	FileSystem::getInstance()->getContentAsStringArray(".", fileName, fileContent);
 	int methodCount = 0;
 	int paramCount = 0;
 	bool haveMethod = false;
@@ -173,7 +173,7 @@ void processFile(const string& fileName) {
 		}
 		lineIdx++;
 	}
-	FileSystem::getInstance()->setContentFromStringArray(".", fileName, &newFileContent);
+	FileSystem::getInstance()->setContentFromStringArray(".", fileName, newFileContent);
 }
 
 int main(int argc, char** argv)

--- a/src/tdme/tools/leveleditor/controller/LevelEditorEntityLibraryScreenController.cpp
+++ b/src/tdme/tools/leveleditor/controller/LevelEditorEntityLibraryScreenController.cpp
@@ -368,7 +368,7 @@ void LevelEditorEntityLibraryScreenController::onValueChanged(GUIElementNode* no
 			popUps->getFileDialogScreenController()->show(
 				modelPath,
 				"Load from: ",
-				&extensions,
+				extensions,
 				"",
 				new LevelEditorEntityLibraryScreenController_onValueChanged_1(this, entityLibrary)
 			);

--- a/src/tdme/tools/leveleditor/controller/LevelEditorScreenController.cpp
+++ b/src/tdme/tools/leveleditor/controller/LevelEditorScreenController.cpp
@@ -319,7 +319,7 @@ void LevelEditorScreenController::onObjectsSelect()
 		selectedObjectList.push_back(t.nextToken());
 	}
 	if (selectedObjectList.empty() == false)
-		view->selectObjects(&selectedObjectList);
+		view->selectObjects(selectedObjectList);
 
 }
 
@@ -673,7 +673,7 @@ void LevelEditorScreenController::onMapLoad()
 	view->getPopUps()->getFileDialogScreenController()->show(
 		mapPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		view->getFileName(),
 		new LevelEditorScreenController_onMapLoad_1(this)
 	);
@@ -687,7 +687,7 @@ void LevelEditorScreenController::onMapSave()
 	view->getPopUps()->getFileDialogScreenController()->show(
 		mapPath->getPath(),
 		"Save to: ",
-		&extensions,
+		extensions,
 		view->getFileName(),
 		new LevelEditorScreenController_onMapSave_2(this)
 	);

--- a/src/tdme/tools/leveleditor/controller/LevelEditorScreenController.h
+++ b/src/tdme/tools/leveleditor/controller/LevelEditorScreenController.h
@@ -259,7 +259,7 @@ public:
 	 * Set up object property preset ids
 	 * @param objectPresetIds object property preset ids
 	 */
-	void setObjectPresetIds(const map<string, vector<PropertyModelClass*>>* objectPresetIds);
+	void setObjectPresetIds(const map<string, vector<PropertyModelClass*>>* objectPresetIds); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Event callback for object properties selection
@@ -348,7 +348,7 @@ public:
 	 * Set up light presets
 	 * @param lightPresetIds light presets
 	 */
-	void setLightPresetsIds(const map<string, LevelEditorLight*>* lightPresetIds);
+	void setLightPresetsIds(const map<string, LevelEditorLight*>* lightPresetIds); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Unselect light presets

--- a/src/tdme/tools/leveleditor/logic/Level.h
+++ b/src/tdme/tools/leveleditor/logic/Level.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vector>
-
 #include <tdme/tdme.h>
 #include <tdme/engine/fwd-tdme.h>
 #include <tdme/engine/model/fwd-tdme.h>
@@ -11,8 +9,6 @@
 #include <tdme/tools/leveleditor/logic/fwd-tdme.h>
 #include <tdme/tools/shared/model/fwd-tdme.h>
 #include <tdme/utils/fwd-tdme.h>
-
-using std::vector;
 
 using tdme::engine::Engine;
 using tdme::engine::Entity;

--- a/src/tdme/tools/leveleditor/views/LevelEditorView.cpp
+++ b/src/tdme/tools/leveleditor/views/LevelEditorView.cpp
@@ -594,7 +594,7 @@ void LevelEditorView::display()
 	engine->getGUI()->render();
 }
 
-void LevelEditorView::selectObjects(vector<string>* entityIds)
+void LevelEditorView::selectObjects(const vector<string>& entityIds)
 {
 	for (auto entityIdToRemove: selectedEntityIds) {
 		auto entityToRemove = engine->getEntity(entityIdToRemove);
@@ -602,7 +602,7 @@ void LevelEditorView::selectObjects(vector<string>* entityIds)
 	}
 	selectedEntityIds.clear();
 	selectedEntityIdsById.clear();
-	for (auto entityId: *entityIds) {
+	for (auto entityId: entityIds) {
 		auto selectedEntity = engine->getEntity(entityId);
 		if (selectedEntity == nullptr) continue;
 		setStandardObjectColorEffect(selectedEntity);
@@ -921,10 +921,10 @@ Model* LevelEditorView::createLevelEditorGroundPlateModel()
 	groupFacesEntityGround.setFaces(&groundFacesGround);
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntityGround);
-	groundGroup->setVertices(&groundVertices);
-	groundGroup->setNormals(&groundNormals);
-	groundGroup->setTextureCoordinates(&groundTextureCoordinates);
-	groundGroup->setFacesEntities(&groupFacesEntities);
+	groundGroup->setVertices(groundVertices);
+	groundGroup->setNormals(groundNormals);
+	groundGroup->setTextureCoordinates(groundTextureCoordinates);
+	groundGroup->setFacesEntities(groupFacesEntities);
 	(*groundPlate->getGroups())[groundGroup->getId()] = groundGroup;
 	(*groundPlate->getSubGroups())[groundGroup->getId()] = groundGroup;
 	ModelHelper::prepareForIndexedRendering(groundPlate);

--- a/src/tdme/tools/leveleditor/views/LevelEditorView.h
+++ b/src/tdme/tools/leveleditor/views/LevelEditorView.h
@@ -185,7 +185,7 @@ public:
 	 * Select objects
 	 * @param entityIds object ids
 	 */
-	void selectObjects(vector<string>* entityIds);
+	void selectObjects(const vector<string>& entityIds);
 
 	/** 
 	 * Select objects by id

--- a/src/tdme/tools/shared/controller/EntityBaseSubScreenController.h
+++ b/src/tdme/tools/shared/controller/EntityBaseSubScreenController.h
@@ -80,7 +80,7 @@ public:
 	 * Set up entity property preset ids
 	 * @param entityPresetIds entity property preset ids
 	 */
-	virtual void setEntityPresetIds(const map<string, vector<PropertyModelClass*>>* entityPresetIds);
+	virtual void setEntityPresetIds(const map<string, vector<PropertyModelClass*>>* entityPresetIds); // TODO: std container: maybe use call by reference
 
 	/** 
 	 * Set up entity properties

--- a/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController.cpp
+++ b/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController.cpp
@@ -218,7 +218,7 @@ void EntityPhysicsSubScreenController::setupModelBoundingVolumeType(LevelEditorE
 	}
 }
 
-void EntityPhysicsSubScreenController::setupBoundingVolumeTypes(int32_t idx, vector<string>* boundingVolumeTypes)
+void EntityPhysicsSubScreenController::setupBoundingVolumeTypes(int32_t idx, const vector<string>& boundingVolumeTypes)
 {
 	auto boundingVolumeTypeDropDownInnerNode = dynamic_cast< GUIParentNode* >((boundingVolumeTypeDropDown[idx]->getScreenNode()->getNodeById(boundingVolumeTypeDropDown[idx]->getId() + "_inner")));
 	auto bvIdx = 0;
@@ -226,7 +226,7 @@ void EntityPhysicsSubScreenController::setupBoundingVolumeTypes(int32_t idx, vec
 	boundingVolumeTypeDropDownSubNodesXML =
 		boundingVolumeTypeDropDownSubNodesXML +
 		"<scrollarea-vertical width=\"100%\" height=\"80\">";
-	for (auto& bvType : *boundingVolumeTypes) {
+	for (auto& bvType : boundingVolumeTypes) {
 		boundingVolumeTypeDropDownSubNodesXML =
 			boundingVolumeTypeDropDownSubNodesXML +
 			"<dropdown-option text=\"" +
@@ -443,7 +443,7 @@ void EntityPhysicsSubScreenController::onBoundingVolumeConvexMeshFile(LevelEdito
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		entity->getBoundingVolumeAt(idx)->getModelMeshFile().length() > 0 ? entity->getBoundingVolumeAt(idx)->getModelMeshFile() : entity->getFileName(),
 		new EntityPhysicsSubScreenController_onBoundingVolumeConvexMeshFile(this, idxFinal, entityFinal)
 	);
@@ -456,7 +456,7 @@ void EntityPhysicsSubScreenController::onBoundingVolumeConvexMeshesFile(LevelEdi
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		Tools::getPath(convexMeshesFile->getController()->getValue().getString()),
 		"Load from: ",
-		&extensions,
+		extensions,
 		Tools::getFileName(convexMeshesFile->getController()->getValue().getString()),
 		new EntityPhysicsSubScreenController_onBoundingVolumeConvexMeshesFile(this, entityFinal)
 	);

--- a/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController.h
+++ b/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController.h
@@ -134,7 +134,7 @@ public:
 	 * @param idx idx
 	 * @param boundingVolumeTypes bounding volume types
 	 */
-	virtual void setupBoundingVolumeTypes(int32_t idx, vector<string>* boundingVolumeTypes);
+	virtual void setupBoundingVolumeTypes(int32_t idx, const vector<string>& boundingVolumeTypes);
 
 	/** 
 	 * Display given bounding volume GUI elements

--- a/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController_GenerateConvexMeshes.cpp
+++ b/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController_GenerateConvexMeshes.cpp
@@ -1,6 +1,7 @@
 #include <tdme/tools/shared/controller/EntityPhysicsSubScreenController_GenerateConvexMeshes.h>
 
 #include <string>
+#include <vector>
 
 #include <ext/v-hacd/src/VHACD_Lib/public/VHACD.h>
 
@@ -40,6 +41,7 @@
 
 using std::string;
 using std::to_string;
+using std::vector;
 
 using namespace VHACD;
 
@@ -363,9 +365,9 @@ Model* EntityPhysicsSubScreenController_GenerateConvexMeshes::createModel(const 
 	groupFacesEntity.setFaces(&faces);
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	group->determineFeatures();
 	(*model->getGroups())["group"] = group;
 	(*model->getSubGroups())["group"] = group;
@@ -419,9 +421,9 @@ Model* EntityPhysicsSubScreenController_GenerateConvexMeshes::createModel(const 
 	groupFacesEntity.setFaces(&faces);
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntities.push_back(groupFacesEntity);
-	group->setVertices(&vertices);
-	group->setNormals(&normals);
-	group->setFacesEntities(&groupFacesEntities);
+	group->setVertices(vertices);
+	group->setNormals(normals);
+	group->setFacesEntities(groupFacesEntities);
 	group->determineFeatures();
 	(*model->getGroups())["group"] = group;
 	(*model->getSubGroups())["group"] = group;

--- a/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController_GenerateConvexMeshes.cpp
+++ b/src/tdme/tools/shared/controller/EntityPhysicsSubScreenController_GenerateConvexMeshes.cpp
@@ -341,7 +341,7 @@ Model* EntityPhysicsSubScreenController_GenerateConvexMeshes::createModel(const 
 				vertices[triangles[i * 3 + 2]]
 			};
 			array<Vector3, 3> faceNormals;
-			ModelHelper::computeNormals(&faceVertices, &faceNormals);
+			ModelHelper::computeNormals(faceVertices, faceNormals);
 			for (auto& normal : faceNormals) {
 				normals.push_back(normal);
 			}
@@ -396,7 +396,7 @@ Model* EntityPhysicsSubScreenController_GenerateConvexMeshes::createModel(const 
 				triangle.getVertices()[2],
 			};
 			array<Vector3, 3> faceNormals;
-			ModelHelper::computeNormals(&faceVertices, &faceNormals);
+			ModelHelper::computeNormals(faceVertices, faceNormals);
 			for (auto& normal : faceNormals) {
 				normals.push_back(normal);
 			}

--- a/src/tdme/tools/shared/controller/FileDialogScreenController.cpp
+++ b/src/tdme/tools/shared/controller/FileDialogScreenController.cpp
@@ -101,7 +101,7 @@ void FileDialogScreenController::setupFileDialogListBox()
 	try {
 		auto directory = cwd;
 		FileDialogScreenController_setupFileDialogListBox_1 extensionsFilter(this);
-		FileSystem::getInstance()->list(directory, &fileList, &extensionsFilter);
+		FileSystem::getInstance()->list(directory, fileList, &extensionsFilter);
 	} catch (Exception& exception) {
 		Console::print(string("FileDialogScreenController::setupFileDialogListBox(): An error occurred: "));
 		Console::println(string(exception.what()));
@@ -132,7 +132,7 @@ void FileDialogScreenController::setupFileDialogListBox()
 	}
 }
 
-void FileDialogScreenController::show(const string& cwd, const string& captionText, vector<string>* extensions, const string& fileName, Action* applyAction)
+void FileDialogScreenController::show(const string& cwd, const string& captionText, vector<string>& extensions, const string& fileName, Action* applyAction)
 {
 	try {
 		this->cwd = FileSystem::getInstance()->getCanonicalPath(cwd, "");
@@ -146,7 +146,7 @@ void FileDialogScreenController::show(const string& cwd, const string& captionTe
 		this->cwd = FileSystem::getInstance()->getCurrentWorkingPathName();
 	}
 	this->captionText = captionText;
-	this->extensions = *extensions;
+	this->extensions = extensions;
 	this->fileName->getController()->setValue(value->set(fileName));
 	setupFileDialogListBox();
 	screenNode->setVisible(true);

--- a/src/tdme/tools/shared/controller/FileDialogScreenController.h
+++ b/src/tdme/tools/shared/controller/FileDialogScreenController.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <string>
@@ -12,8 +11,8 @@
 #include <tdme/gui/events/GUIActionListener.h>
 #include <tdme/gui/events/GUIChangeListener.h>
 
-using std::vector;
 using std::string;
+using std::vector;
 
 using tdme::tools::shared::controller::ScreenController;
 using tdme::gui::events::GUIActionListener;
@@ -82,7 +81,7 @@ public:
 	 * @param applyAction apply action
 	 * @throws IOException 
 	 */
-	virtual void show(const string& cwd, const string& captionText, vector<string>* extensions, const string& fileName, Action* applyAction);
+	virtual void show(const string& cwd, const string& captionText, vector<string>& extensions, const string& fileName, Action* applyAction);
 
 	/** 
 	 * Abort the file dialog pop up

--- a/src/tdme/tools/shared/controller/ModelEditorScreenController.cpp
+++ b/src/tdme/tools/shared/controller/ModelEditorScreenController.cpp
@@ -400,7 +400,7 @@ void ModelEditorScreenController::onLODLevelLoadModel() {
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		entityLodLevel->getFileName() != ""?Tools::getPath(entityLodLevel->getFileName()):modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		Tools::getFileName(entityLodLevel->getFileName()),
 		new ModelEditorScreenController_onLODModelLoad(this)
 	);
@@ -632,7 +632,7 @@ void ModelEditorScreenController::onMaterialLoadDiffuseTexture() {
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		material->getDiffuseTextureFileName() != ""?material->getDiffuseTexturePathName():modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		material->getDiffuseTextureFileName(),
 		new ModelEditorScreenController_onMaterialLoadTexture(this, materialsMaterialDiffuseTexture)
 	);
@@ -646,7 +646,7 @@ void ModelEditorScreenController::onMaterialLoadDiffuseTransparencyTexture() {
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		material->getDiffuseTransparencyTextureFileName() != ""?material->getDiffuseTransparencyTexturePathName():modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		material->getDiffuseTransparencyTextureFileName(),
 		new ModelEditorScreenController_onMaterialLoadTexture(this, materialsMaterialDiffuseTransparencyTexture)
 	);
@@ -660,7 +660,7 @@ void ModelEditorScreenController::onMaterialLoadNormalTexture() {
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		material->getNormalTextureFileName() != ""?material->getNormalTexturePathName():modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		material->getNormalTextureFileName(),
 		new ModelEditorScreenController_onMaterialLoadTexture(this, materialsMaterialNormalTexture)
 	);
@@ -674,7 +674,7 @@ void ModelEditorScreenController::onMaterialLoadSpecularTexture() {
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		material->getSpecularTextureFileName() != ""?material->getSpecularTexturePathName():modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		material->getSpecularTextureFileName(),
 		new ModelEditorScreenController_onMaterialLoadTexture(this, materialsMaterialNormalTexture)
 	);
@@ -915,7 +915,7 @@ void ModelEditorScreenController::onModelLoad()
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		modelPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		view->getFileName(),
 		new ModelEditorScreenController_onModelLoad_2(this)
 	);
@@ -937,7 +937,7 @@ void ModelEditorScreenController::onModelSave()
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		modelPath->getPath(),
 		"Save from: ",
-		&extensions,
+		extensions,
 		fileName,
 		new ModelEditorScreenController_onModelSave_3(this)
 	);

--- a/src/tdme/tools/shared/controller/ModelEditorScreenController.h
+++ b/src/tdme/tools/shared/controller/ModelEditorScreenController.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <string>

--- a/src/tdme/tools/shared/controller/ParticleSystemScreenController.cpp
+++ b/src/tdme/tools/shared/controller/ParticleSystemScreenController.cpp
@@ -276,7 +276,7 @@ void ParticleSystemScreenController::unsetEntityProperties()
 	entityBaseSubScreenController->unsetEntityProperties();
 }
 
-void ParticleSystemScreenController::setParticleSystemTypes(const vector<string>* particleSystemTypesCollection)
+void ParticleSystemScreenController::setParticleSystemTypes(const vector<string>& particleSystemTypesCollection)
 {
 	auto particleSystemTypesInnerNode = dynamic_cast< GUIParentNode* >(particleSystemTypes->getScreenNode()->getNodeById(particleSystemTypes->getId() + "_inner"));
 	auto idx = 0;
@@ -286,7 +286,7 @@ void ParticleSystemScreenController::setParticleSystemTypes(const vector<string>
 		"<scrollarea-vertical id=\"" +
 		particleSystemTypes->getId() +
 		"_inner_scrollarea\" width=\"100%\" height=\"100\">\n";
-	for (auto particleSystem: *particleSystemTypesCollection) {
+	for (auto particleSystem: particleSystemTypesCollection) {
 		particleSystemTypesInnerNodeSubNodesXML =
 			particleSystemTypesInnerNodeSubNodesXML +
 			"<dropdown-option text=\"" +
@@ -309,7 +309,7 @@ void ParticleSystemScreenController::setParticleSystemTypes(const vector<string>
 	}
 }
 
-void ParticleSystemScreenController::setParticleSystemEmitters(const vector<string>* emittersCollection)
+void ParticleSystemScreenController::setParticleSystemEmitters(const vector<string>& emittersCollection)
 {
 	auto particleSystemEmittersInnerNode = dynamic_cast< GUIParentNode* >((particleSystemEmitters->getScreenNode()->getNodeById(particleSystemEmitters->getId() + "_inner")));
 	auto idx = 0;
@@ -319,7 +319,7 @@ void ParticleSystemScreenController::setParticleSystemEmitters(const vector<stri
 		"<scrollarea-vertical id=\"" +
 		particleSystemEmitters->getId() +
 		"_inner_scrollarea\" width=\"100%\" height=\"100\">\n";
-	for (auto particleSystemEmitter: *emittersCollection) {
+	for (auto particleSystemEmitter: emittersCollection) {
 		particleSystemEmittersInnerNodeSubNodesXML =
 			particleSystemEmittersInnerNodeSubNodesXML +
 			"<dropdown-option text=\"" +
@@ -743,7 +743,7 @@ void ParticleSystemScreenController::onParticleSystemLoad()
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		particleSystemPath->getPath(),
 		"Load from: ",
-		&extensions,
+		extensions,
 		view->getFileName(),
 		new ParticleSystemScreenController_onParticleSystemLoad_2(this)
 	);
@@ -762,7 +762,7 @@ void ParticleSystemScreenController::onEntitySave()
 	view->getPopUpsViews()->getFileDialogScreenController()->show(
 		particleSystemPath->getPath(),
 		"Save from: ",
-		&extensions,
+		extensions,
 		fileName,
 		new ParticleSystemScreenController_onEntitySave_3(this)
 );
@@ -827,7 +827,7 @@ void ParticleSystemScreenController::onActionPerformed(GUIActionListener_Type* t
 				view->getPopUpsViews()->getFileDialogScreenController()->show(
 					modelPath->getPath(),
 					"Load from: ",
-					&extensions,
+					extensions,
 					"",
 					new ParticleSystemScreenController_onActionPerformed_4(this)
 				);

--- a/src/tdme/tools/shared/controller/ParticleSystemScreenController.h
+++ b/src/tdme/tools/shared/controller/ParticleSystemScreenController.h
@@ -199,13 +199,13 @@ public:
 	 * Set up particle system types
 	 * @param particleSystemTypesCollection particle system types
 	 */
-	void setParticleSystemTypes(const vector<string>* particleSystemTypesCollection);
+	void setParticleSystemTypes(const vector<string>& particleSystemTypesCollection);
 
 	/** 
 	 * Set up emitters
 	 * @param emittersCollection emitters
 	 */
-	void setParticleSystemEmitters(const vector<string>* emittersCollection);
+	void setParticleSystemEmitters(const vector<string>& emittersCollection);
 
 	/** 
 	 * On quit

--- a/src/tdme/tools/shared/model/LevelEditorEntity.cpp
+++ b/src/tdme/tools/shared/model/LevelEditorEntity.cpp
@@ -1,7 +1,5 @@
 #include <tdme/tools/shared/model/LevelEditorEntity.h>
 
-#include <vector>
-
 #include <tdme/engine/model/Model.h>
 #include <tdme/math/Vector3.h>
 #include <tdme/tools/shared/model/LevelEditorEntity_EntityType.h>
@@ -9,8 +7,6 @@
 #include <tdme/tools/shared/model/LevelEditorEntityModel.h>
 #include <tdme/tools/shared/model/LevelEditorEntityParticleSystem.h>
 #include <tdme/tools/shared/model/LevelEditorEntityPhysics.h>
-
-using std::vector;
 
 using tdme::tools::shared::model::LevelEditorEntity;
 using tdme::engine::model::Model;

--- a/src/tdme/tools/shared/model/LevelEditorEntityLibrary.cpp
+++ b/src/tdme/tools/shared/model/LevelEditorEntityLibrary.cpp
@@ -1,9 +1,7 @@
 #include <tdme/tools/shared/model/LevelEditorEntityLibrary.h>
 
 #include <algorithm>
-#include <map>
 #include <string>
-#include <vector>
 
 #include <tdme/engine/fileio/models/ModelReader.h>
 #include <tdme/engine/model/Model.h>
@@ -19,10 +17,8 @@
 #include <tdme/utils/ExceptionBase.h>
 #include <tdme/utils/StringUtils.h>
 
-using std::map;
 using std::remove;
 using std::to_string;
-using std::vector;
 using std::string;
 
 using tdme::tools::shared::model::LevelEditorEntityLibrary;

--- a/src/tdme/tools/shared/model/ModelProperties.cpp
+++ b/src/tdme/tools/shared/model/ModelProperties.cpp
@@ -1,15 +1,11 @@
 #include <tdme/tools/shared/model/ModelProperties.h>
 
 #include <algorithm>
-#include <map>
 #include <string>
-#include <vector>
 
 #include <tdme/tools/shared/model/PropertyModelClass.h>
 
-using std::map;
 using std::remove;
-using std::vector;
 using std::string;
 
 using tdme::tools::shared::model::ModelProperties;

--- a/src/tdme/tools/shared/tools/Tools.cpp
+++ b/src/tdme/tools/shared/tools/Tools.cpp
@@ -252,10 +252,10 @@ Model* Tools::createGroundModel(float width, float depth, float y)
 	vector<FacesEntity> groupFacesEntities;
 	groupFacesEntityGround.setFaces(&groundFacesGround);
 	groupFacesEntities.push_back(groupFacesEntityGround);
-	groundGroup->setVertices(&groundVertices);
-	groundGroup->setNormals(&groundNormals);
-	groundGroup->setTextureCoordinates(&groundTextureCoordinates);
-	groundGroup->setFacesEntities(&groupFacesEntities);
+	groundGroup->setVertices(groundVertices);
+	groundGroup->setNormals(groundNormals);
+	groundGroup->setTextureCoordinates(groundTextureCoordinates);
+	groundGroup->setFacesEntities(groupFacesEntities);
 	(*ground->getGroups())["ground"] = groundGroup;
 	(*ground->getSubGroups())["ground"] = groundGroup;
 	ModelHelper::prepareForIndexedRendering(ground);

--- a/src/tdme/tools/shared/tools/Tools.cpp
+++ b/src/tdme/tools/shared/tools/Tools.cpp
@@ -119,16 +119,6 @@ void Tools::convertToArray(const string& text, array<float, 3>& array) /* throws
 	}
 }
 
-void Tools::convertToArray(const string& text, array<float, 4>* array) /* throws(NumberFormatException) */
-{
-	auto i = 0;
-	StringTokenizer t;
-	t.tokenize(text, ",");
-	while (t.hasMoreTokens() && i < array->size()) {
-		(*array)[i++] = Float::parseFloat(t.nextToken());
-	}
-}
-
 void Tools::convertToArray(const string& text, array<float, 4>& array) /* throws(NumberFormatException) */
 {
 	auto i = 0;

--- a/src/tdme/tools/shared/tools/Tools.h
+++ b/src/tdme/tools/shared/tools/Tools.h
@@ -71,13 +71,6 @@ public:
 	 * @param text text
 	 * @param array array
 	 */
-	static void convertToArray(const string& text, array<float, 4>* array) /* throws(NumberFormatException) */;
-
-	/**
-	 * Convert string to array
-	 * @param text text
-	 * @param array array
-	 */
 	static void convertToArray(const string& text, array<float, 4>& array) /* throws(NumberFormatException) */;
 
 	/** 

--- a/src/tdme/tools/shared/views/EntityBoundingVolumeView.cpp
+++ b/src/tdme/tools/shared/views/EntityBoundingVolumeView.cpp
@@ -67,7 +67,7 @@ void EntityBoundingVolumeView::initialize()
 		"Convex Mesh"
 	};
 	for (auto i = 0; i < EntityPhysicsSubScreenController::MODEL_BOUNDINGVOLUME_COUNT; i++) {
-		entityPhysicsSubScreenController->setupBoundingVolumeTypes(i, &boundingVolumeTypes);
+		entityPhysicsSubScreenController->setupBoundingVolumeTypes(i, boundingVolumeTypes);
 		entityPhysicsSubScreenController->selectBoundingVolume(i, EntityPhysicsSubScreenController_BoundingVolumeType::NONE);
 	}
 }

--- a/src/tdme/tools/shared/views/SharedParticleSystemView.cpp
+++ b/src/tdme/tools/shared/views/SharedParticleSystemView.cpp
@@ -248,7 +248,7 @@ void SharedParticleSystemView::initialize()
 	particleSystemTypes.push_back("None");
 	particleSystemTypes.push_back("Object Particle System");
 	particleSystemTypes.push_back("Points Particle System");
-	particleSystemScreenController->setParticleSystemTypes(&particleSystemTypes);
+	particleSystemScreenController->setParticleSystemTypes(particleSystemTypes);
 	vector<string> particleSystemEmitters;
 	particleSystemEmitters.push_back("None");
 	particleSystemEmitters.push_back("Point Particle Emitter");
@@ -256,7 +256,7 @@ void SharedParticleSystemView::initialize()
 	particleSystemEmitters.push_back("Circle Particle Emitter");
 	particleSystemEmitters.push_back("Circle Particle Emitter Plane Velocity");
 	particleSystemEmitters.push_back("Sphere Particle Emitter");
-	particleSystemScreenController->setParticleSystemEmitters(&particleSystemEmitters);
+	particleSystemScreenController->setParticleSystemEmitters(particleSystemEmitters);
 	particleSystemScreenController->getEntityDisplaySubScreenController()->setupDisplay();
 	updateGUIElements();
 	initParticleSystemRequested = true;

--- a/src/tdme/utils/ByteBuffer.h
+++ b/src/tdme/utils/ByteBuffer.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <vector>

--- a/src/tdme/utils/FloatBuffer.h
+++ b/src/tdme/utils/FloatBuffer.h
@@ -58,18 +58,7 @@ public:
 	 * Put float values into float buffer
 	 * @param values values
 	 */
-	inline FloatBuffer* put(array<float, 2>* values) {
-		for (int i = 0; i < values->size(); i++) {
-			put((*values)[i]);
-		}
-		return this;
-	}
-
-	/**
-	 * Put float values into float buffer
-	 * @param values values
-	 */
-	inline FloatBuffer* put(array<float, 2>& values) {
+	inline FloatBuffer* put(const array<float, 2>& values) {
 		for (int i = 0; i < values.size(); i++) {
 			put(values[i]);
 		}

--- a/src/tdme/utils/Properties.cpp
+++ b/src/tdme/utils/Properties.cpp
@@ -39,7 +39,7 @@ void Properties::load(const string& pathName, const string& fileName) throw (Fil
 {
 	properties.clear();
 	vector<string> lines;
-	FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, &lines);
+	FileSystem::getInstance()->getContentAsStringArray(pathName, fileName, lines);
 	for (int i = 0; i < lines.size(); i++) {
 		string line = StringUtils::trim(lines[i]);
 		if (line.length() == 0 || StringUtils::startsWith(line, "#")) continue;
@@ -59,5 +59,5 @@ void Properties::store(const string& pathName, const string& fileName) throw (Fi
 		string value = it->second;
 		result.push_back(key + "=" + value);
 	}
-	FileSystem::getInstance()->setContentFromStringArray(pathName, fileName, &result);
+	FileSystem::getInstance()->setContentFromStringArray(pathName, fileName, result);
 }

--- a/src/tdme/utils/VectorIteratorMultiple.h
+++ b/src/tdme/utils/VectorIteratorMultiple.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <vector>


### PR DESCRIPTION
- Change pointer to vector in method arguments to reference of std::arry
- Change pointer to vector in method arguments to reference of std::vector
- Comment methods using pointers to std containers (mainly std::map) as arguments with a TODO note
- minor fixes/cleanup